### PR TITLE
updates arch in build step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ package:
 	@echo "***********************"
 	@echo ""
 	cd lambda/service; \
-  		env GOOS=linux GOARCH=amd64 go build -tags lambda.norpc -o $(WORKING_DIR)/lambda/bin/service/bootstrap; \
+  		env GOOS=linux GOARCH=arm64 go build -tags lambda.norpc -o $(WORKING_DIR)/lambda/bin/service/bootstrap; \
 		cd $(WORKING_DIR)/lambda/bin/service/ ; \
 			zip -r $(WORKING_DIR)/lambda/bin/service/$(PACKAGE_NAME) .
 


### PR DESCRIPTION
- updates GOARCH in build step
- this results in a `Runtime.InvalidEntrypoint` error when the lambda is invoked