### PR TITLE
Fix permissions

### DIFF
--- a/internal/handler/compute/permissions_handler.go
+++ b/internal/handler/compute/permissions_handler.go
@@ -55,7 +55,9 @@ func GetNodePermissionsHandler(ctx context.Context, request events.APIGatewayV2H
 	// Initialize stores
 	dynamoDBClient := dynamodb.NewFromConfig(cfg)
 	nodeAccessTable := os.Getenv("NODE_ACCESS_TABLE")
+	nodesTable := os.Getenv("COMPUTE_NODES_TABLE")
 	nodeAccessStore := store_dynamodb.NewNodeAccessDatabaseStore(dynamoDBClient, nodeAccessTable)
+	nodeStore := store_dynamodb.NewNodeDatabaseStore(dynamoDBClient, nodesTable)
 	
 	// Initialize PostgreSQL if available
 	var teamStore store_postgres.TeamStore
@@ -75,6 +77,7 @@ func GetNodePermissionsHandler(ctx context.Context, request events.APIGatewayV2H
 	}
 	
 	permissionService := service.NewPermissionService(nodeAccessStore, teamStore)
+	permissionService.SetNodeStore(nodeStore)
 	
 	// Check if user has access to the node
 	hasAccess, err := permissionService.CheckNodeAccess(ctx, userId, nodeUuid, organizationId)

--- a/terraform/gateway.tf
+++ b/terraform/gateway.tf
@@ -4,7 +4,7 @@ resource "aws_apigatewayv2_api" "accounts_service_api" {
   description   = "API for the lambda-based Accounts API"
   cors_configuration {
     allow_origins     = local.cors_allowed_origins
-    allow_methods = ["OPTIONS", "GET", "POST", "PATCH", "DELETE"]
+    allow_methods = ["OPTIONS", "GET", "POST", "PUT", "PATCH", "DELETE"]
     allow_headers = ["*"]
     allow_credentials = true
     expose_headers = ["*"]


### PR DESCRIPTION
Adding auto-repair of permissions for compute node owner. Compute node owner should always have access.

Also added PUT to CORS