### PR TITLE
Adding Permission Lambda

### DIFF
--- a/cmd/lambda/check-access/main.go
+++ b/cmd/lambda/check-access/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/pennsieve/account-service/internal/handler/internal"
+)
+
+func main() {
+	// Start the Lambda handler
+	// This uses the LambdaHandler which accepts raw JSON events
+	lambda.Start(internal.LambdaHandler)
+}

--- a/docs/check-access-lambda-api.md
+++ b/docs/check-access-lambda-api.md
@@ -1,0 +1,339 @@
+# Check Access Lambda API Contract
+
+## Overview
+
+The Check Access Lambda is an internal AWS Lambda function that verifies whether a user has access to a specific compute node within an organization. This function is designed for service-to-service communication only and is not exposed through API Gateway.
+
+## Function Details
+
+- **Function Name Pattern**: `{environment}-account-service-check-access-lambda-use1`
+- **Runtime**: Go (provided.al2)
+- **Handler**: `check-access`
+- **Timeout**: 30 seconds
+- **Memory**: 256 MB
+
+## Authentication
+
+This Lambda function uses IAM-based authentication. Only authorized AWS services and accounts with proper IAM permissions can invoke this function directly.
+
+## API Contract
+
+### Request Format
+
+The Lambda accepts a JSON request with the following structure:
+
+```json
+{
+  "userNodeId": "string",
+  "nodeUuid": "string",
+  "organizationId": "string"
+}
+```
+
+#### Request Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `userNodeId` | string | Yes | User node ID in format `N:user:uuid` |
+| `nodeUuid` | string | Yes | Compute node UUID (plain UUID format) |
+| `organizationId` | string | No | Organization node ID in format `N:organization:uuid` |
+
+### Response Format
+
+The Lambda returns a JSON response with the following structure:
+
+```json
+{
+  "hasAccess": true,
+  "accessType": "owner",
+  "accessSource": "direct",
+  "teamId": "N:team:uuid",
+  "nodeUuid": "node-uuid",
+  "userNodeId": "N:user:uuid",
+  "organizationId": "N:organization:uuid"
+}
+```
+
+#### Response Fields
+
+| Field | Type | Always Present | Description |
+|-------|------|----------------|-------------|
+| `hasAccess` | boolean | Yes | Whether the user has access to the node |
+| `accessType` | string | No | Type of access: `"owner"`, `"shared"`, `"workspace"` (only present if hasAccess=true) |
+| `accessSource` | string | No | How access was granted: `"direct"`, `"workspace"`, `"team"` (only present if hasAccess=true) |
+| `teamId` | string | No | Team node ID if access is through a team (only present for team-based access) |
+| `nodeUuid` | string | Yes | Echo of the requested node UUID |
+| `userNodeId` | string | Yes | Echo of the requested user node ID |
+| `organizationId` | string | Yes | Echo of the requested organization ID |
+
+## Access Types
+
+The Lambda checks for access in the following order:
+
+1. **Direct Access**: User has explicit access to the node (owner or shared)
+2. **Workspace Access**: Node is shared with the entire workspace/organization
+3. **Team Access**: User is part of a team that has access to the node
+
+### Access Type Values
+
+- `owner`: User is the owner of the compute node
+- `shared`: User has been granted shared access to the node
+- `workspace`: Access granted through workspace/organization membership
+
+### Access Source Values
+
+- `direct`: User has direct access entry in the access table
+- `workspace`: Access is granted to the entire workspace
+- `team`: Access is granted through a team the user belongs to
+
+## Error Handling
+
+### Input Validation
+
+If required fields are missing or empty, the Lambda returns:
+- `hasAccess: false`
+- No error is raised (graceful failure)
+
+### Internal Errors
+
+For infrastructure errors (DynamoDB, PostgreSQL connection issues):
+- Returns an error in the Lambda execution
+- Error details are logged internally
+- The invoking service should handle the error appropriately
+
+## Usage Examples
+
+### Example 1: User with Direct Access
+
+**Request:**
+```json
+{
+  "userNodeId": "N:user:123e4567-e89b-12d3-a456-426614174000",
+  "nodeUuid": "987f6543-e21b-34c5-d678-123456789012",
+  "organizationId": "N:organization:555e6666-a77b-88c9-d999-111111111111"
+}
+```
+
+**Response:**
+```json
+{
+  "hasAccess": true,
+  "accessType": "owner",
+  "accessSource": "direct",
+  "nodeUuid": "987f6543-e21b-34c5-d678-123456789012",
+  "userNodeId": "N:user:123e4567-e89b-12d3-a456-426614174000",
+  "organizationId": "N:organization:555e6666-a77b-88c9-d999-111111111111"
+}
+```
+
+### Example 2: User with No Access
+
+**Request:**
+```json
+{
+  "userNodeId": "N:user:999e9999-e89b-12d3-a456-999999999999",
+  "nodeUuid": "987f6543-e21b-34c5-d678-123456789012",
+  "organizationId": "N:organization:555e6666-a77b-88c9-d999-111111111111"
+}
+```
+
+**Response:**
+```json
+{
+  "hasAccess": false,
+  "nodeUuid": "987f6543-e21b-34c5-d678-123456789012",
+  "userNodeId": "N:user:999e9999-e89b-12d3-a456-999999999999",
+  "organizationId": "N:organization:555e6666-a77b-88c9-d999-111111111111"
+}
+```
+
+### Example 3: User with Team Access
+
+**Request:**
+```json
+{
+  "userNodeId": "N:user:444e4444-e89b-12d3-a456-444444444444",
+  "nodeUuid": "abc12345-f67g-89h0-i123-456789012345",
+  "organizationId": "N:organization:555e6666-a77b-88c9-d999-111111111111"
+}
+```
+
+**Response:**
+```json
+{
+  "hasAccess": true,
+  "accessType": "shared",
+  "accessSource": "team",
+  "teamId": "N:team:777e7777-a11b-22c3-d444-555555555555",
+  "nodeUuid": "abc12345-f67g-89h0-i123-456789012345",
+  "userNodeId": "N:user:444e4444-e89b-12d3-a456-444444444444",
+  "organizationId": "N:organization:555e6666-a77b-88c9-d999-111111111111"
+}
+```
+
+## Invocation
+
+### Using AWS SDK (Go Example)
+
+```go
+import (
+    "github.com/aws/aws-sdk-go-v2/service/lambda"
+    "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+)
+
+func checkUserAccess(client *lambda.Client, userNodeId, nodeUuid, orgId string) (*CheckUserNodeAccessResponse, error) {
+    functionName := os.Getenv("CHECK_ACCESS_LAMBDA_NAME")
+    if functionName == "" {
+        functionName = "prod-account-service-check-access-lambda-use1"
+    }
+    
+    request := CheckUserNodeAccessRequest{
+        UserNodeId:     userNodeId,
+        NodeUuid:       nodeUuid,
+        OrganizationId: orgId,
+    }
+    
+    payload, err := json.Marshal(request)
+    if err != nil {
+        return nil, err
+    }
+    
+    result, err := client.Invoke(context.Background(), &lambda.InvokeInput{
+        FunctionName:   aws.String(functionName),
+        InvocationType: types.InvocationTypeRequestResponse,
+        Payload:        payload,
+    })
+    
+    if err != nil {
+        return nil, err
+    }
+    
+    var response CheckUserNodeAccessResponse
+    err = json.Unmarshal(result.Payload, &response)
+    if err != nil {
+        return nil, err
+    }
+    
+    return &response, nil
+}
+```
+
+### Using AWS CLI
+
+```bash
+aws lambda invoke \
+  --function-name "prod-account-service-check-access-lambda-use1" \
+  --payload '{"userNodeId":"N:user:123","nodeUuid":"456","organizationId":"N:organization:789"}' \
+  --cli-binary-format raw-in-base64-out \
+  response.json
+
+cat response.json
+```
+
+## IAM Permissions Required
+
+To invoke this Lambda function, the calling service needs the following IAM permission:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "lambda:InvokeFunction",
+      "Resource": "arn:aws:lambda:{region}:{account-id}:function:{environment}-account-service-check-access-lambda-use1"
+    }
+  ]
+}
+```
+
+## Terraform Integration
+
+### Available Outputs
+
+The Lambda function configuration is exported via Terraform outputs for use by other services:
+
+| Output Name | Description | Example Value |
+|------------|-------------|---------------|
+| `check_access_lambda_arn` | Full ARN of the Lambda function for IAM permissions | `arn:aws:lambda:us-east-1:123456789:function:prod-account-service-check-access-lambda-use1` |
+| `check_access_lambda_invoke_arn` | Invoke ARN for API Gateway integrations | `arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:123456789:function:prod-account-service-check-access-lambda-use1/invocations` |
+| `check_access_lambda_name` | Function name for direct invocation | `prod-account-service-check-access-lambda-use1` |
+
+### Using in Other Services
+
+Other services can reference these outputs using Terraform remote state:
+
+```hcl
+# Import account-service outputs
+data "terraform_remote_state" "account_service" {
+  backend = "s3"
+  config = {
+    bucket = "pennsieve-terraform-state-${var.environment_name}"
+    key    = "account-service/terraform.tfstate"
+    region = var.aws_region
+  }
+}
+
+# Grant IAM permission to invoke the Lambda
+resource "aws_iam_role_policy" "invoke_check_access" {
+  name = "${var.environment_name}-${var.service_name}-invoke-check-access"
+  role = aws_iam_role.my_service_role.id
+  
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = "lambda:InvokeFunction"
+      Resource = data.terraform_remote_state.account_service.outputs.check_access_lambda_arn
+    }]
+  })
+}
+
+# Pass the function name to your application via environment variable
+resource "aws_ecs_task_definition" "my_service" {
+  # ... other configuration ...
+  
+  container_definitions = jsonencode([{
+    # ... other container config ...
+    environment = [
+      {
+        name  = "CHECK_ACCESS_LAMBDA_NAME"
+        value = data.terraform_remote_state.account_service.outputs.check_access_lambda_name
+      }
+    ]
+  }])
+}
+```
+
+## Performance Considerations
+
+- The Lambda performs database lookups in DynamoDB and potentially PostgreSQL
+- Response times typically range from 50-200ms depending on data complexity
+- The function checks access in order (direct → workspace → team) and returns immediately upon finding access
+
+## Monitoring
+
+Key CloudWatch metrics to monitor:
+- Invocation count
+- Error rate
+- Duration
+- Throttles
+
+Log groups are created automatically with the naming pattern:
+`/aws/lambda/{environment}-account-service-check-access-lambda-use1`
+
+Logs are automatically streamed to Datadog for centralized monitoring and alerting.
+
+## Dependencies
+
+The Lambda depends on:
+- **DynamoDB**: Node access table for permission lookups
+- **PostgreSQL**: Organization database for team membership queries (optional)
+- **VPC**: Runs within VPC to access RDS PostgreSQL
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0.0 | 2024 | Initial release with basic access checking |
+| 1.1.0 | 2024 | Added team ID return for team-based access |

--- a/docs/internal-lambda-usage.md
+++ b/docs/internal-lambda-usage.md
@@ -1,0 +1,236 @@
+# Internal Lambda Function: Check User Node Access
+
+## Overview
+
+The `check-user-node-access` Lambda function is a private, internal-only service for checking if a user has access to a compute node. This function is NOT exposed through API Gateway and can only be invoked directly by other AWS services with proper IAM permissions.
+
+## Purpose
+
+This Lambda function allows other Pennsieve services to verify user access to compute nodes without going through the public API Gateway. This is useful for:
+
+- Backend services that need to validate permissions
+- Batch processing jobs
+- Internal workflows
+- Service-to-service authentication checks
+
+## Request Format
+
+```json
+{
+  "userNodeId": "N:user:uuid",
+  "nodeUuid": "node-uuid",
+  "organizationId": "N:organization:uuid"
+}
+```
+
+### Fields
+
+- `userNodeId` (required): The user's node ID in format `N:user:uuid`
+- `nodeUuid` (required): The compute node UUID to check access for
+- `organizationId` (optional): The organization node ID in format `N:organization:uuid`
+
+## Response Format
+
+```json
+{
+  "hasAccess": true,
+  "accessType": "owner",
+  "accessSource": "direct",
+  "teamId": "",
+  "nodeUuid": "node-uuid",
+  "userNodeId": "N:user:uuid",
+  "organizationId": "N:organization:uuid"
+}
+```
+
+### Fields
+
+- `hasAccess`: Boolean indicating if the user has access
+- `accessType`: Type of access ("owner", "shared", "workspace", or empty)
+- `accessSource`: How the user has access ("direct", "workspace", "team", or empty)
+- `teamId`: If access is through a team, the team ID (currently not fully implemented)
+- `nodeUuid`: Echo of the requested node UUID
+- `userNodeId`: Echo of the requested user node ID
+- `organizationId`: Echo of the requested organization ID
+
+## How to Invoke from Another Service
+
+### Using AWS SDK for Go
+
+```go
+package main
+
+import (
+    "context"
+    "encoding/json"
+    "github.com/aws/aws-sdk-go-v2/config"
+    "github.com/aws/aws-sdk-go-v2/service/lambda"
+)
+
+type CheckAccessRequest struct {
+    UserNodeId     string `json:"userNodeId"`
+    NodeUuid       string `json:"nodeUuid"`
+    OrganizationId string `json:"organizationId"`
+}
+
+type CheckAccessResponse struct {
+    HasAccess    bool   `json:"hasAccess"`
+    AccessType   string `json:"accessType"`
+    AccessSource string `json:"accessSource"`
+}
+
+func CheckUserAccess(ctx context.Context, userNodeId, nodeUuid, orgId string) (bool, error) {
+    // Load AWS configuration
+    cfg, err := config.LoadDefaultConfig(ctx)
+    if err != nil {
+        return false, err
+    }
+
+    // Create Lambda client
+    lambdaClient := lambda.NewFromConfig(cfg)
+
+    // Prepare request
+    request := CheckAccessRequest{
+        UserNodeId:     userNodeId,
+        NodeUuid:       nodeUuid,
+        OrganizationId: orgId,
+    }
+
+    payload, err := json.Marshal(request)
+    if err != nil {
+        return false, err
+    }
+
+    // Invoke Lambda function
+    result, err := lambdaClient.Invoke(ctx, &lambda.InvokeInput{
+        FunctionName: aws.String("prod-account-service-check-access-lambda-use1"),
+        Payload:      payload,
+    })
+    if err != nil {
+        return false, err
+    }
+
+    // Parse response
+    var response CheckAccessResponse
+    err = json.Unmarshal(result.Payload, &response)
+    if err != nil {
+        return false, err
+    }
+
+    return response.HasAccess, nil
+}
+```
+
+### Using AWS SDK for Python
+
+```python
+import json
+import boto3
+
+def check_user_access(user_node_id, node_uuid, organization_id):
+    """
+    Check if a user has access to a compute node
+    
+    Args:
+        user_node_id: User node ID (e.g., "N:user:uuid")
+        node_uuid: Compute node UUID
+        organization_id: Organization node ID (e.g., "N:organization:uuid")
+    
+    Returns:
+        dict: Response with hasAccess and access details
+    """
+    
+    # Create Lambda client
+    lambda_client = boto3.client('lambda')
+    
+    # Prepare request
+    request = {
+        'userNodeId': user_node_id,
+        'nodeUuid': node_uuid,
+        'organizationId': organization_id
+    }
+    
+    # Invoke Lambda function
+    response = lambda_client.invoke(
+        FunctionName='prod-account-service-check-access-lambda-use1',
+        InvocationType='RequestResponse',
+        Payload=json.dumps(request)
+    )
+    
+    # Parse response
+    result = json.loads(response['Payload'].read())
+    return result
+```
+
+### Using AWS CLI (for testing)
+
+```bash
+aws lambda invoke \
+  --function-name prod-account-service-check-access-lambda-use1 \
+  --payload '{"userNodeId":"N:user:123","nodeUuid":"node-456","organizationId":"N:organization:789"}' \
+  --cli-binary-format raw-in-base64-out \
+  response.json
+
+cat response.json
+```
+
+## IAM Permissions Required
+
+The calling service must have the following IAM permission:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "lambda:InvokeFunction",
+      "Resource": "arn:aws:lambda:us-east-1:ACCOUNT_ID:function:ENV-account-service-check-access-lambda-use1"
+    }
+  ]
+}
+```
+
+## Setting Up Access for Your Service
+
+To allow your service to invoke this Lambda function:
+
+1. **Add IAM Permission to Your Service's Role**:
+   - Add the `lambda:InvokeFunction` permission for this specific Lambda function
+   - Use the Lambda ARN from Terraform output: `check_access_lambda_arn`
+
+2. **Update Lambda Resource Policy** (if needed):
+   - Contact the Account Service team to add your service to the allowed invokers
+   - Provide your service's IAM role ARN or Lambda function ARN
+
+3. **Use Correct Function Name**:
+   - Development: `dev-account-service-check-access-lambda-use1`
+   - Production: `prod-account-service-check-access-lambda-use1`
+
+## Security Considerations
+
+1. **No Public Access**: This Lambda is not exposed through API Gateway
+2. **IAM Authentication**: Access is controlled through IAM roles and policies
+3. **VPC Isolation**: The Lambda runs within the VPC for database access
+4. **Audit Logging**: All invocations are logged to CloudWatch
+
+## Error Handling
+
+The Lambda function will:
+- Return `hasAccess: false` for invalid inputs (missing userNodeId or nodeUuid)
+- Return actual errors only for system failures (database connection issues, etc.)
+- Log all requests and responses to CloudWatch for debugging
+
+## Performance Considerations
+
+- **Timeout**: 30 seconds
+- **Memory**: 256 MB
+- **Cold Start**: ~2-3 seconds (includes VPC ENI attachment)
+- **Warm Invocation**: ~50-200ms
+
+## Support
+
+For issues or questions about this internal Lambda function:
+- Contact the Account Service team
+- Check CloudWatch logs for debugging
+- Open an issue in the account-service repository

--- a/internal/handler/internal/check_access_handler.go
+++ b/internal/handler/internal/check_access_handler.go
@@ -1,0 +1,239 @@
+package internal
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"os"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/pennsieve/account-service/internal/models"
+	"github.com/pennsieve/account-service/internal/service"
+	"github.com/pennsieve/account-service/internal/store_dynamodb"
+	"github.com/pennsieve/account-service/internal/store_postgres"
+	"github.com/pennsieve/account-service/internal/utils"
+)
+
+// CheckUserNodeAccessRequest is the request structure for checking user access to a node
+type CheckUserNodeAccessRequest struct {
+	UserNodeId     string `json:"userNodeId"`     // User node ID in format "N:user:uuid"
+	NodeUuid       string `json:"nodeUuid"`        // Compute node UUID
+	OrganizationId string `json:"organizationId"`  // Organization node ID in format "N:organization:uuid"
+}
+
+// CheckUserNodeAccessResponse is the response structure for access check
+type CheckUserNodeAccessResponse struct {
+	HasAccess      bool   `json:"hasAccess"`
+	AccessType     string `json:"accessType,omitempty"`     // "owner", "shared", "workspace", "team", or empty if no access
+	AccessSource   string `json:"accessSource,omitempty"`   // "direct", "workspace", "team", or empty
+	TeamId         string `json:"teamId,omitempty"`         // If access is through a team, which team
+	NodeUuid       string `json:"nodeUuid"`
+	UserNodeId     string `json:"userNodeId"`
+	OrganizationId string `json:"organizationId"`
+}
+
+// CheckUserNodeAccessHandler is a private Lambda handler that checks if a user has access to a compute node
+// This function is only invokable by other AWS services, not through API Gateway
+//
+// Input: CheckUserNodeAccessRequest (JSON)
+// Output: CheckUserNodeAccessResponse (JSON)
+//
+// This handler is designed for internal service-to-service communication only.
+// Authentication is handled through IAM roles and Lambda invocation permissions.
+func CheckUserNodeAccessHandler(ctx context.Context, request CheckUserNodeAccessRequest) (CheckUserNodeAccessResponse, error) {
+	log.Printf("CheckUserNodeAccessHandler: Checking access for user %s to node %s in org %s",
+		request.UserNodeId, request.NodeUuid, request.OrganizationId)
+
+	response := CheckUserNodeAccessResponse{
+		HasAccess:      false,
+		NodeUuid:       request.NodeUuid,
+		UserNodeId:     request.UserNodeId,
+		OrganizationId: request.OrganizationId,
+	}
+
+	// Validate input
+	if request.UserNodeId == "" {
+		log.Printf("CheckUserNodeAccessHandler: Missing userNodeId")
+		return response, nil // Return false access, not an error
+	}
+
+	if request.NodeUuid == "" {
+		log.Printf("CheckUserNodeAccessHandler: Missing nodeUuid")
+		return response, nil // Return false access, not an error
+	}
+
+	// Load AWS config
+	cfg, err := utils.LoadAWSConfig(ctx)
+	if err != nil {
+		log.Printf("CheckUserNodeAccessHandler: Error loading AWS config: %v", err)
+		return response, err
+	}
+
+	// Initialize DynamoDB stores
+	dynamoDBClient := dynamodb.NewFromConfig(cfg)
+	nodeAccessTable := os.Getenv("NODE_ACCESS_TABLE")
+	nodeAccessStore := store_dynamodb.NewNodeAccessDatabaseStore(dynamoDBClient, nodeAccessTable)
+
+	// Initialize container to get PostgreSQL connection for team lookups
+	var teamStore store_postgres.TeamStore
+	var orgStore store_postgres.OrganizationStore
+	appContainer, err := utils.GetContainer(ctx, cfg)
+	if err == nil && appContainer != nil {
+		db := appContainer.PostgresDB()
+		if db != nil {
+			teamStore = store_postgres.NewPostgresTeamStore(db)
+			orgStore = store_postgres.NewPostgresOrganizationStore(db)
+		}
+	}
+	// Note: It's okay if stores are nil - it just means no team access checking
+
+	// Initialize permission service
+	permissionService := service.NewPermissionService(nodeAccessStore, teamStore)
+	if orgStore != nil {
+		permissionService.SetOrganizationStore(orgStore)
+	}
+
+	// Check access using the permission service
+	hasAccess, err := permissionService.CheckNodeAccess(ctx, request.UserNodeId, request.NodeUuid, request.OrganizationId)
+	if err != nil {
+		log.Printf("CheckUserNodeAccessHandler: Error checking access: %v", err)
+		return response, err
+	}
+
+	response.HasAccess = hasAccess
+
+	// If user has access, get more details about the type of access
+	if hasAccess {
+		err = enrichAccessDetails(ctx, &response, nodeAccessStore, teamStore, orgStore)
+		if err != nil {
+			// Log but don't fail - we already know they have access
+			log.Printf("CheckUserNodeAccessHandler: Error enriching access details: %v", err)
+		}
+	}
+
+	log.Printf("CheckUserNodeAccessHandler: User %s has access=%v to node %s (type=%s, source=%s)",
+		request.UserNodeId, response.HasAccess, request.NodeUuid, response.AccessType, response.AccessSource)
+
+	return response, nil
+}
+
+// enrichAccessDetails adds information about how the user has access
+func enrichAccessDetails(ctx context.Context, response *CheckUserNodeAccessResponse, 
+	nodeAccessStore store_dynamodb.NodeAccessStore, teamStore store_postgres.TeamStore,
+	orgStore store_postgres.OrganizationStore) error {
+	
+	nodeId := models.FormatNodeId(response.NodeUuid)
+	userEntityId := models.FormatEntityId(models.EntityTypeUser, response.UserNodeId)
+	
+	// Check direct user access first
+	hasDirectAccess, err := nodeAccessStore.HasAccess(ctx, userEntityId, nodeId)
+	if err == nil && hasDirectAccess {
+		// Get the actual access entry to determine if owner or shared
+		accessList, err := nodeAccessStore.GetNodeAccess(ctx, response.NodeUuid)
+		if err == nil {
+			for _, access := range accessList {
+				if access.EntityId == userEntityId {
+					response.AccessType = string(access.AccessType)
+					response.AccessSource = "direct"
+					return nil
+				}
+			}
+		}
+	}
+	
+	// Check workspace access
+	if response.OrganizationId != "" {
+		workspaceEntityId := models.FormatEntityId(models.EntityTypeWorkspace, response.OrganizationId)
+		hasWorkspaceAccess, err := nodeAccessStore.HasAccess(ctx, workspaceEntityId, nodeId)
+		if err == nil && hasWorkspaceAccess {
+			response.AccessType = string(models.AccessTypeWorkspace)
+			response.AccessSource = "workspace"
+			return nil
+		}
+	}
+	
+	// Check team access (if stores are available)
+	if teamStore != nil && orgStore != nil && response.OrganizationId != "" {
+		// Get numeric IDs from node IDs
+		userIdInt, err := orgStore.GetUserIdByNodeId(ctx, response.UserNodeId)
+		if err == nil {
+			orgIdInt, err := orgStore.GetOrganizationIdByNodeId(ctx, response.OrganizationId)
+			if err == nil {
+				// Get all teams the user belongs to
+				teams, err := teamStore.GetUserTeams(ctx, userIdInt, orgIdInt)
+				if err == nil {
+					// Check which team has access to the node
+					for _, team := range teams {
+						teamEntityId := models.FormatEntityId(models.EntityTypeTeam, team.TeamNodeId)
+						hasTeamAccess, err := nodeAccessStore.HasAccess(ctx, teamEntityId, nodeId)
+						if err == nil && hasTeamAccess {
+							response.AccessType = string(models.AccessTypeShared)
+							response.AccessSource = "team"
+							response.TeamId = team.TeamNodeId
+							return nil
+						}
+					}
+				}
+			}
+		}
+		
+		// If we get here, we know they have team access but couldn't identify the specific team
+		response.AccessType = string(models.AccessTypeShared)
+		response.AccessSource = "team"
+	}
+	
+	return nil
+}
+
+// LambdaHandler is the entry point for AWS Lambda
+// It wraps CheckUserNodeAccessHandler to handle Lambda's event format
+func LambdaHandler(ctx context.Context, event json.RawMessage) (CheckUserNodeAccessResponse, error) {
+	var request CheckUserNodeAccessRequest
+	
+	// Try to unmarshal the event
+	err := json.Unmarshal(event, &request)
+	if err != nil {
+		log.Printf("LambdaHandler: Error unmarshaling request: %v", err)
+		return CheckUserNodeAccessResponse{}, err
+	}
+	
+	return CheckUserNodeAccessHandler(ctx, request)
+}
+
+// APIGatewayHandler wraps the handler for API Gateway events (if needed in the future)
+// This is included for completeness but should NOT be exposed through public API Gateway
+func APIGatewayHandler(ctx context.Context, request events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	var checkRequest CheckUserNodeAccessRequest
+	
+	// Parse request body
+	if err := json.Unmarshal([]byte(request.Body), &checkRequest); err != nil {
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: 400,
+			Body:       `{"error": "Invalid request body"}`,
+		}, nil
+	}
+	
+	// Call the main handler
+	response, err := CheckUserNodeAccessHandler(ctx, checkRequest)
+	if err != nil {
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: 500,
+			Body:       `{"error": "Internal server error"}`,
+		}, nil
+	}
+	
+	// Marshal response
+	responseBody, err := json.Marshal(response)
+	if err != nil {
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: 500,
+			Body:       `{"error": "Error marshaling response"}`,
+		}, nil
+	}
+	
+	return events.APIGatewayV2HTTPResponse{
+		StatusCode: 200,
+		Body:       string(responseBody),
+	}, nil
+}

--- a/internal/handler/internal/check_access_handler_test.go
+++ b/internal/handler/internal/check_access_handler_test.go
@@ -1,0 +1,195 @@
+package internal
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/pennsieve/account-service/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// Mock for NodeAccessStore
+type MockNodeAccessStore struct {
+	mock.Mock
+}
+
+func (m *MockNodeAccessStore) GrantAccess(ctx context.Context, access models.NodeAccess) error {
+	args := m.Called(ctx, access)
+	return args.Error(0)
+}
+
+func (m *MockNodeAccessStore) RevokeAccess(ctx context.Context, entityId, nodeId string) error {
+	args := m.Called(ctx, entityId, nodeId)
+	return args.Error(0)
+}
+
+func (m *MockNodeAccessStore) HasAccess(ctx context.Context, entityId, nodeId string) (bool, error) {
+	args := m.Called(ctx, entityId, nodeId)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockNodeAccessStore) GetNodeAccess(ctx context.Context, nodeUuid string) ([]models.NodeAccess, error) {
+	args := m.Called(ctx, nodeUuid)
+	return args.Get(0).([]models.NodeAccess), args.Error(1)
+}
+
+func (m *MockNodeAccessStore) GetEntityAccess(ctx context.Context, entityId string) ([]models.NodeAccess, error) {
+	args := m.Called(ctx, entityId)
+	return args.Get(0).([]models.NodeAccess), args.Error(1)
+}
+
+func (m *MockNodeAccessStore) GetWorkspaceNodes(ctx context.Context, organizationId string) ([]models.NodeAccess, error) {
+	args := m.Called(ctx, organizationId)
+	return args.Get(0).([]models.NodeAccess), args.Error(1)
+}
+
+func (m *MockNodeAccessStore) BatchCheckAccess(ctx context.Context, entityIds []string, nodeId string) (bool, error) {
+	args := m.Called(ctx, entityIds, nodeId)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockNodeAccessStore) RemoveAllNodeAccess(ctx context.Context, nodeUuid string) error {
+	args := m.Called(ctx, nodeUuid)
+	return args.Error(0)
+}
+
+func (m *MockNodeAccessStore) UpdateNodeAccessScope(ctx context.Context, nodeUuid string, accessScope models.NodeAccessScope, organizationId, grantedBy string) error {
+	args := m.Called(ctx, nodeUuid, accessScope, organizationId, grantedBy)
+	return args.Error(0)
+}
+
+func TestCheckUserNodeAccessHandler_Success(t *testing.T) {
+	// Skip this test in unit test mode since it requires full AWS environment
+	// This test requires DynamoDB tables to be configured
+	t.Skip("Skipping integration test that requires full AWS environment")
+	
+	ctx := context.Background()
+	
+	request := CheckUserNodeAccessRequest{
+		UserNodeId:     "N:user:test-user-123",
+		NodeUuid:       "node-uuid-456",
+		OrganizationId: "N:organization:org-789",
+	}
+	
+	// Note: In real tests, you would need to set up the environment
+	// and mock the permission service dependencies
+	// For now, this is a basic structure test
+	
+	response, err := CheckUserNodeAccessHandler(ctx, request)
+	
+	// The handler should not return an error even if access is false
+	assert.NoError(t, err)
+	assert.Equal(t, request.NodeUuid, response.NodeUuid)
+	assert.Equal(t, request.UserNodeId, response.UserNodeId)
+	assert.Equal(t, request.OrganizationId, response.OrganizationId)
+}
+
+func TestCheckUserNodeAccessHandler_MissingUserNodeId(t *testing.T) {
+	ctx := context.Background()
+	
+	request := CheckUserNodeAccessRequest{
+		UserNodeId:     "", // Missing
+		NodeUuid:       "node-uuid-456",
+		OrganizationId: "N:organization:org-789",
+	}
+	
+	response, err := CheckUserNodeAccessHandler(ctx, request)
+	
+	// Should not error, but should return false access
+	assert.NoError(t, err)
+	assert.False(t, response.HasAccess)
+	assert.Equal(t, request.NodeUuid, response.NodeUuid)
+}
+
+func TestCheckUserNodeAccessHandler_MissingNodeUuid(t *testing.T) {
+	ctx := context.Background()
+	
+	request := CheckUserNodeAccessRequest{
+		UserNodeId:     "N:user:test-user-123",
+		NodeUuid:       "", // Missing
+		OrganizationId: "N:organization:org-789",
+	}
+	
+	response, err := CheckUserNodeAccessHandler(ctx, request)
+	
+	// Should not error, but should return false access
+	assert.NoError(t, err)
+	assert.False(t, response.HasAccess)
+	assert.Equal(t, request.UserNodeId, response.UserNodeId)
+}
+
+func TestLambdaHandler(t *testing.T) {
+	// Skip this test in unit test mode since it requires full AWS environment
+	// This test requires DynamoDB tables to be configured
+	t.Skip("Skipping integration test that requires full AWS environment")
+	
+	ctx := context.Background()
+	
+	request := CheckUserNodeAccessRequest{
+		UserNodeId:     "N:user:test-user-123",
+		NodeUuid:       "node-uuid-456",
+		OrganizationId: "N:organization:org-789",
+	}
+	
+	// Marshal request to JSON
+	requestJSON, err := json.Marshal(request)
+	assert.NoError(t, err)
+	
+	// Test Lambda handler wrapper
+	response, err := LambdaHandler(ctx, requestJSON)
+	
+	// Should handle the request (even if it returns false due to missing setup)
+	assert.NoError(t, err)
+	assert.Equal(t, request.NodeUuid, response.NodeUuid)
+	assert.Equal(t, request.UserNodeId, response.UserNodeId)
+}
+
+func TestLambdaHandler_InvalidJSON(t *testing.T) {
+	ctx := context.Background()
+	
+	// Invalid JSON
+	invalidJSON := json.RawMessage(`{"invalid json}`)
+	
+	_, err := LambdaHandler(ctx, invalidJSON)
+	
+	// Should return an error for invalid JSON
+	assert.Error(t, err)
+}
+
+func TestEnrichAccessDetails(t *testing.T) {
+	ctx := context.Background()
+	mockStore := new(MockNodeAccessStore)
+	
+	response := &CheckUserNodeAccessResponse{
+		HasAccess:      true,
+		NodeUuid:       "node-123",
+		UserNodeId:     "N:user:user-456",
+		OrganizationId: "N:organization:org-789",
+	}
+	
+	nodeId := models.FormatNodeId(response.NodeUuid)
+	userEntityId := models.FormatEntityId(models.EntityTypeUser, response.UserNodeId)
+	
+	// Mock direct user access
+	mockStore.On("HasAccess", ctx, userEntityId, nodeId).Return(true, nil)
+	
+	// Mock getting node access details
+	accessList := []models.NodeAccess{
+		{
+			EntityId:   userEntityId,
+			NodeId:     nodeId,
+			AccessType: models.AccessTypeOwner,
+		},
+	}
+	mockStore.On("GetNodeAccess", ctx, response.NodeUuid).Return(accessList, nil)
+	
+	err := enrichAccessDetails(ctx, response, mockStore, nil, nil)
+	
+	assert.NoError(t, err)
+	assert.Equal(t, string(models.AccessTypeOwner), response.AccessType)
+	assert.Equal(t, "direct", response.AccessSource)
+	
+	mockStore.AssertExpectations(t)
+}

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -28,3 +28,19 @@ resource "aws_cloudwatch_log_group" "provisioner_fargate_log_group" {
 
   tags = local.common_tags
 }
+
+// Create log group for check-access Lambda
+resource "aws_cloudwatch_log_group" "check_access_lambda_log_group" {
+  name              = "/aws/lambda/${aws_lambda_function.check_user_node_access.function_name}"
+  retention_in_days = 30
+  tags              = local.common_tags
+}
+
+// Send logs from check-access Lambda to Datadog
+resource "aws_cloudwatch_log_subscription_filter" "check_access_lambda_datadog_subscription" {
+  name            = "${aws_cloudwatch_log_group.check_access_lambda_log_group.name}-subscription"
+  log_group_name  = aws_cloudwatch_log_group.check_access_lambda_log_group.name
+  filter_pattern  = ""
+  destination_arn = data.terraform_remote_state.region.outputs.datadog_delivery_stream_arn
+  role_arn        = data.terraform_remote_state.region.outputs.cw_logs_to_datadog_logs_firehose_role_arn
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -41,3 +41,19 @@ output "compute_nodes_table_name" {
 output "compute_nodes_access_table_name" {
   value = aws_dynamodb_table.compute_node_access_table.name
 }
+
+# Output the Lambda function ARN for other services to use
+output "check_access_lambda_arn" {
+  value = aws_lambda_function.check_user_node_access.arn
+  description = "ARN of the internal check access Lambda function"
+}
+
+output "check_access_lambda_invoke_arn" {
+  value = aws_lambda_function.check_user_node_access.invoke_arn
+  description = "Invoke ARN of the internal check access Lambda function (for API Gateway integrations)"
+}
+
+output "check_access_lambda_name" {
+  value = aws_lambda_function.check_user_node_access.function_name
+  description = "Name of the internal check access Lambda function"
+}


### PR DESCRIPTION
Adding Lambda to check permissions on a node.
This can be used internally to check permissions before invoking a workflow