### PR TITLE
fix: adds guards for ECR access

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -49,6 +49,7 @@ var ErrOnlyWorkspaceAdminsCanCreateNodes = errors.New("only workspace administra
 var ErrOnlyAccountOwnerCanDetachNodes = errors.New("only the account owner can detach nodes")
 var ErrOrganizationNotFound = errors.New("organization not found")
 var ErrInvalidOrganizationIdFormat = errors.New("invalid organization ID format - expected format: N:organization:uuid")
+var ErrAccountNotRegistered = errors.New("account is not registered")
 var ErrBadRequest = errors.New("bad request")
 var ErrTooManySecrets = errors.New("too many secrets (max 50)")
 var ErrSecretKeyTooLong = errors.New("secret key exceeds max length (256)")

--- a/internal/handler/compute/app_store_access_handler.go
+++ b/internal/handler/compute/app_store_access_handler.go
@@ -8,9 +8,11 @@ import (
 	"os"
 
 	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
 	appStoreEcr "github.com/pennsieve/account-service/internal/ecr"
 	"github.com/pennsieve/account-service/internal/errors"
+	"github.com/pennsieve/account-service/internal/store_dynamodb"
 	"github.com/pennsieve/account-service/internal/utils"
 )
 
@@ -44,6 +46,59 @@ func PostAppStoreAccessHandler(ctx context.Context, request events.APIGatewayV2H
 		}, nil
 	}
 
+	cfg, err := utils.LoadAWSConfig(ctx)
+	if err != nil {
+		log.Println(err.Error())
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: http.StatusInternalServerError,
+			Body:       errors.ComputeHandlerError(handlerName, errors.ErrConfig),
+		}, nil
+	}
+
+	// Verify the caller owns the account before granting ECR access
+	userId, err := utils.GetUserIdFromRequest(request)
+	if err != nil {
+		log.Printf("Error getting user ID: %v", err)
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: http.StatusUnauthorized,
+			Body:       errors.ComputeHandlerError(handlerName, errors.ErrUnauthorized),
+		}, nil
+	}
+
+	dynamoDBClient := dynamodb.NewFromConfig(cfg)
+	accountsTable := os.Getenv("ACCOUNTS_TABLE")
+	accountsStore := store_dynamodb.NewAccountDatabaseStore(dynamoDBClient, accountsTable)
+	accounts, err := accountsStore.GetByAccountId(ctx, req.AccountId)
+	if err != nil {
+		log.Printf("Error looking up account %s: %v", req.AccountId, err)
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: http.StatusInternalServerError,
+			Body:       errors.ComputeHandlerError(handlerName, errors.ErrDynamoDB),
+		}, nil
+	}
+	if len(accounts) == 0 {
+		log.Printf("Account %s is not registered", req.AccountId)
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: http.StatusForbidden,
+			Body:       errors.ComputeHandlerError(handlerName, errors.ErrAccountNotRegistered),
+		}, nil
+	}
+
+	owned := false
+	for _, account := range accounts {
+		if account.UserId == userId {
+			owned = true
+			break
+		}
+	}
+	if !owned {
+		log.Printf("User %s does not own account %s", userId, req.AccountId)
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: http.StatusForbidden,
+			Body:       errors.ComputeHandlerError(handlerName, errors.ErrAccountDoesNotBelongToUser),
+		}, nil
+	}
+
 	repoURL := os.Getenv("APP_STORE_ECR_REPOSITORY")
 	if repoURL == "" {
 		log.Println("APP_STORE_ECR_REPOSITORY environment variable not set")
@@ -61,15 +116,6 @@ func PostAppStoreAccessHandler(ctx context.Context, request events.APIGatewayV2H
 		log.Printf("Skipping ECR policy update in test environment for account %s", req.AccountId)
 		return events.APIGatewayV2HTTPResponse{
 			StatusCode: http.StatusOK,
-		}, nil
-	}
-
-	cfg, err := utils.LoadAWSConfig(ctx)
-	if err != nil {
-		log.Println(err.Error())
-		return events.APIGatewayV2HTTPResponse{
-			StatusCode: http.StatusInternalServerError,
-			Body:       errors.ComputeHandlerError(handlerName, errors.ErrConfig),
 		}, nil
 	}
 

--- a/internal/store_dynamodb/account_store.go
+++ b/internal/store_dynamodb/account_store.go
@@ -13,6 +13,7 @@ import (
 type DynamoDBStore interface {
 	Insert(context.Context, Account) error
 	GetById(context.Context, string) (Account, error)
+	GetByAccountId(context.Context, string) ([]Account, error)
 	Get(context.Context, string, map[string]string) ([]Account, error)
 	Update(context.Context, Account) error
 	Delete(context.Context, string) error
@@ -60,6 +61,34 @@ func (r *AccountDatabaseStore) GetById(ctx context.Context, uuid string) (Accoun
 	}
 
 	return account, nil
+}
+
+func (r *AccountDatabaseStore) GetByAccountId(ctx context.Context, accountId string) ([]Account, error) {
+	accounts := []Account{}
+
+	expr, err := expression.NewBuilder().WithFilter(
+		expression.Name("accountId").Equal(expression.Value(accountId)),
+	).Build()
+	if err != nil {
+		return accounts, fmt.Errorf("error building expression: %w", err)
+	}
+
+	response, err := r.DB.Scan(ctx, &dynamodb.ScanInput{
+		ExpressionAttributeNames:  expr.Names(),
+		ExpressionAttributeValues: expr.Values(),
+		FilterExpression:          expr.Filter(),
+		TableName:                 aws.String(r.TableName),
+	})
+	if err != nil {
+		return accounts, fmt.Errorf("error getting account by accountId: %w", err)
+	}
+
+	err = attributevalue.UnmarshalListOfMaps(response.Items, &accounts)
+	if err != nil {
+		return accounts, fmt.Errorf("error unmarshaling accounts: %w", err)
+	}
+
+	return accounts, nil
 }
 
 func (r *AccountDatabaseStore) Get(ctx context.Context, organizationId string, params map[string]string) ([]Account, error) {


### PR DESCRIPTION
  Adds some guards for https://app.clickup.com/t/868hqdh1y:

  1. Extract user identity from the Bearer token claims via GetUserIdFromRequest → returns 401 if missing                                  
  2. Look up the account by accountId in DynamoDB → returns 403 if not registered                                                        
  3. Verify the caller owns the account by matching userId → returns 403 if not owned   