### PR TITLE
fix: updates to support a initial policy creation

### DIFF
--- a/internal/ecr/policy.go
+++ b/internal/ecr/policy.go
@@ -28,8 +28,34 @@ type PolicyStatement struct {
 }
 
 // PolicyPrincipal represents the principal block in a policy statement.
+// AWS may return the AWS field as a single string or as an array of strings,
+// so we use a custom unmarshaler to handle both forms.
 type PolicyPrincipal struct {
 	AWS []string `json:"AWS"`
+}
+
+func (p *PolicyPrincipal) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		AWS json.RawMessage `json:"AWS"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if len(raw.AWS) == 0 {
+		p.AWS = []string{}
+		return nil
+	}
+	// Try array first
+	if raw.AWS[0] == '[' {
+		return json.Unmarshal(raw.AWS, &p.AWS)
+	}
+	// Single string
+	var single string
+	if err := json.Unmarshal(raw.AWS, &single); err != nil {
+		return err
+	}
+	p.AWS = []string{single}
+	return nil
 }
 
 // AppStorePolicy manages cross-account pull access on an ECR repository.

--- a/internal/ecr/policy_test.go
+++ b/internal/ecr/policy_test.go
@@ -1,6 +1,7 @@
 package ecr
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -44,6 +45,43 @@ func TestAddPrincipal_AppendsToExistingStatement(t *testing.T) {
 	AddPrincipal(&policy, "arn:aws:iam::222222222222:root")
 
 	assert.Len(t, policy.Statement, 1)
+	assert.Equal(t, []string{
+		"arn:aws:iam::111111111111:root",
+		"arn:aws:iam::222222222222:root",
+	}, policy.Statement[0].Principal.AWS)
+}
+
+func TestPolicyPrincipal_UnmarshalJSON_SingleString(t *testing.T) {
+	policyJSON := `{
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Sid": "AllowCrossAccountPull",
+			"Effect": "Allow",
+			"Principal": {"AWS": "arn:aws:iam::111111111111:root"},
+			"Action": ["ecr:GetDownloadUrlForLayer"]
+		}]
+	}`
+
+	var policy PolicyDocument
+	err := json.Unmarshal([]byte(policyJSON), &policy)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"arn:aws:iam::111111111111:root"}, policy.Statement[0].Principal.AWS)
+}
+
+func TestPolicyPrincipal_UnmarshalJSON_Array(t *testing.T) {
+	policyJSON := `{
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Sid": "AllowCrossAccountPull",
+			"Effect": "Allow",
+			"Principal": {"AWS": ["arn:aws:iam::111111111111:root", "arn:aws:iam::222222222222:root"]},
+			"Action": ["ecr:GetDownloadUrlForLayer"]
+		}]
+	}`
+
+	var policy PolicyDocument
+	err := json.Unmarshal([]byte(policyJSON), &policy)
+	assert.NoError(t, err)
 	assert.Equal(t, []string{
 		"arn:aws:iam::111111111111:root",
 		"arn:aws:iam::222222222222:root",


### PR DESCRIPTION
- updates to support a fresh policy

fixes error:
```
{"message":"error verifying ECR repository policy: error parsing ECR policy: json: cannot unmarshal string into Go struct field                     
PolicyPrincipal.Statement.Principal.AWS of type []string"}   
```