### PR TITLE
fix: Added AllowServiceLinkedRoles statement to the cross-account role policy

### DIFF
--- a/internal/handler/compute/role_policy_handler.go
+++ b/internal/handler/compute/role_policy_handler.go
@@ -20,12 +20,11 @@ import (
 // future roles.
 //
 // The policy uses permissions boundaries to prevent privilege escalation:
-// - Statement 1: Allow service actions (no IAM mutation)
+// - Statement 1: Allow service actions (no IAM mutation, plus iam:CreateServiceLinkedRole)
 // - Statement 2: Allow IAM role/policy management for Terraform
 // - Statement 3: Deny CreateRole without permissions boundary attached
 // - Statement 4: Deny removing permissions boundaries from roles
 // - Statement 5: Deny modifying the cross-account role itself (Pennsieve-Compute-* and legacy ROLE-*)
-// - Statement 6: Allow creating service-linked roles for AWS services (autoscaling, ecs)
 const rolePolicyDocument = `{
 	"Version": "2012-10-17",
 	"Statement": [
@@ -52,7 +51,8 @@ const rolePolicyDocument = `{
 				"ssm:RemoveTagsFromResource",
 				"ssm:ListTagsForResource",
 				"autoscaling:*",
-				"sts:GetCallerIdentity"
+				"sts:GetCallerIdentity",
+				"iam:CreateServiceLinkedRole"
 			],
 			"Resource": "*"
 		},
@@ -105,20 +105,6 @@ const rolePolicyDocument = `{
 			"Effect": "Deny",
 			"Action": "iam:DeleteRolePermissionsBoundary",
 			"Resource": "*"
-		},
-		{
-			"Sid": "AllowServiceLinkedRoles",
-			"Effect": "Allow",
-			"Action": "iam:CreateServiceLinkedRole",
-			"Resource": "arn:aws:iam::*:role/aws-service-role/*",
-			"Condition": {
-				"StringEquals": {
-					"iam:AWSServiceName": [
-						"autoscaling.amazonaws.com",
-						"ecs.amazonaws.com"
-					]
-				}
-			}
 		},
 		{
 			"Sid": "DenySelfModification",

--- a/internal/handler/compute/role_policy_handler.go
+++ b/internal/handler/compute/role_policy_handler.go
@@ -25,6 +25,7 @@ import (
 // - Statement 3: Deny CreateRole without permissions boundary attached
 // - Statement 4: Deny removing permissions boundaries from roles
 // - Statement 5: Deny modifying the cross-account role itself (Pennsieve-Compute-* and legacy ROLE-*)
+// - Statement 6: Allow creating service-linked roles for AWS services (autoscaling, ecs)
 const rolePolicyDocument = `{
 	"Version": "2012-10-17",
 	"Statement": [
@@ -106,6 +107,20 @@ const rolePolicyDocument = `{
 			"Resource": "*"
 		},
 		{
+			"Sid": "AllowServiceLinkedRoles",
+			"Effect": "Allow",
+			"Action": "iam:CreateServiceLinkedRole",
+			"Resource": "arn:aws:iam::*:role/aws-service-role/*",
+			"Condition": {
+				"StringEquals": {
+					"iam:AWSServiceName": [
+						"autoscaling.amazonaws.com",
+						"ecs.amazonaws.com"
+					]
+				}
+			}
+		},
+		{
 			"Sid": "DenySelfModification",
 			"Effect": "Deny",
 			"Action": [
@@ -123,6 +138,11 @@ const rolePolicyDocument = `{
 		}
 	]
 }`
+
+// RolePolicyJSON returns the raw role policy document for testing.
+func RolePolicyJSON() string {
+	return rolePolicyDocument
+}
 
 // roleConfigResponse is the JSON envelope returned by the role-policy endpoint.
 type roleConfigResponse struct {

--- a/internal/handler/compute/rolepolicy_test/role_policy_test.go
+++ b/internal/handler/compute/rolepolicy_test/role_policy_test.go
@@ -1,0 +1,105 @@
+package rolepolicy_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/pennsieve/account-service/internal/handler/compute"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type policyStatement struct {
+	Sid       string                                `json:"Sid"`
+	Effect    string                                `json:"Effect"`
+	Action    interface{}                           `json:"Action"`
+	Resource  interface{}                           `json:"Resource"`
+	Condition map[string]map[string]json.RawMessage `json:"Condition"`
+}
+
+type policyDocument struct {
+	Version   string            `json:"Version"`
+	Statement []policyStatement `json:"Statement"`
+}
+
+func parsePolicy(t *testing.T) policyDocument {
+	t.Helper()
+	var doc policyDocument
+	require.NoError(t, json.Unmarshal([]byte(compute.RolePolicyJSON()), &doc))
+	return doc
+}
+
+func findStatement(t *testing.T, doc policyDocument, sid string) policyStatement {
+	t.Helper()
+	for _, s := range doc.Statement {
+		if s.Sid == sid {
+			return s
+		}
+	}
+	t.Fatalf("statement %q not found", sid)
+	return policyStatement{}
+}
+
+func TestRolePolicyDocument_IsValidJSON(t *testing.T) {
+	doc := parsePolicy(t)
+	assert.Equal(t, "2012-10-17", doc.Version)
+	assert.Len(t, doc.Statement, 6)
+}
+
+func TestRolePolicyDocument_AllowServiceLinkedRoles(t *testing.T) {
+	doc := parsePolicy(t)
+	stmt := findStatement(t, doc, "AllowServiceLinkedRoles")
+
+	assert.Equal(t, "Allow", stmt.Effect)
+	assert.Equal(t, "iam:CreateServiceLinkedRole", stmt.Action)
+	assert.Equal(t, "arn:aws:iam::*:role/aws-service-role/*", stmt.Resource)
+
+	raw := stmt.Condition["StringEquals"]["iam:AWSServiceName"]
+	var names []string
+	require.NoError(t, json.Unmarshal(raw, &names))
+	assert.Contains(t, names, "autoscaling.amazonaws.com")
+	assert.Contains(t, names, "ecs.amazonaws.com")
+}
+
+func TestRolePolicyDocument_AllExpectedStatementsPresent(t *testing.T) {
+	doc := parsePolicy(t)
+
+	expected := map[string]string{
+		"AllowServices":                 "Allow",
+		"AllowIAMRoleManagement":        "Allow",
+		"AllowServiceLinkedRoles":       "Allow",
+		"DenyCreateRoleWithoutBoundary": "Deny",
+		"DenyBoundaryStripping":         "Deny",
+		"DenySelfModification":          "Deny",
+	}
+
+	found := make(map[string]string)
+	for _, stmt := range doc.Statement {
+		found[stmt.Sid] = stmt.Effect
+	}
+
+	for sid, wantEffect := range expected {
+		gotEffect, ok := found[sid]
+		assert.True(t, ok, "statement %q not found", sid)
+		assert.Equal(t, wantEffect, gotEffect, "statement %q wrong effect", sid)
+	}
+}
+
+func TestRolePolicyDocument_AutoscalingWildcardInAllowServices(t *testing.T) {
+	doc := parsePolicy(t)
+	stmt := findStatement(t, doc, "AllowServices")
+
+	actions, ok := stmt.Action.([]interface{})
+	require.True(t, ok)
+	assert.Contains(t, actions, "autoscaling:*")
+}
+
+func TestRolePolicyDocument_DenySelfModification_ProtectsComputeRoles(t *testing.T) {
+	doc := parsePolicy(t)
+	stmt := findStatement(t, doc, "DenySelfModification")
+
+	resources, ok := stmt.Resource.([]interface{})
+	require.True(t, ok)
+	assert.Contains(t, resources, "arn:aws:iam::*:role/Pennsieve-Compute-*")
+	assert.Contains(t, resources, "arn:aws:iam::*:role/ROLE-*")
+}

--- a/internal/handler/compute/rolepolicy_test/role_policy_test.go
+++ b/internal/handler/compute/rolepolicy_test/role_policy_test.go
@@ -43,22 +43,16 @@ func findStatement(t *testing.T, doc policyDocument, sid string) policyStatement
 func TestRolePolicyDocument_IsValidJSON(t *testing.T) {
 	doc := parsePolicy(t)
 	assert.Equal(t, "2012-10-17", doc.Version)
-	assert.Len(t, doc.Statement, 6)
+	assert.Len(t, doc.Statement, 5)
 }
 
-func TestRolePolicyDocument_AllowServiceLinkedRoles(t *testing.T) {
+func TestRolePolicyDocument_CreateServiceLinkedRoleInAllowServices(t *testing.T) {
 	doc := parsePolicy(t)
-	stmt := findStatement(t, doc, "AllowServiceLinkedRoles")
+	stmt := findStatement(t, doc, "AllowServices")
 
-	assert.Equal(t, "Allow", stmt.Effect)
-	assert.Equal(t, "iam:CreateServiceLinkedRole", stmt.Action)
-	assert.Equal(t, "arn:aws:iam::*:role/aws-service-role/*", stmt.Resource)
-
-	raw := stmt.Condition["StringEquals"]["iam:AWSServiceName"]
-	var names []string
-	require.NoError(t, json.Unmarshal(raw, &names))
-	assert.Contains(t, names, "autoscaling.amazonaws.com")
-	assert.Contains(t, names, "ecs.amazonaws.com")
+	actions, ok := stmt.Action.([]interface{})
+	require.True(t, ok)
+	assert.Contains(t, actions, "iam:CreateServiceLinkedRole")
 }
 
 func TestRolePolicyDocument_AllExpectedStatementsPresent(t *testing.T) {
@@ -67,7 +61,6 @@ func TestRolePolicyDocument_AllExpectedStatementsPresent(t *testing.T) {
 	expected := map[string]string{
 		"AllowServices":                 "Allow",
 		"AllowIAMRoleManagement":        "Allow",
-		"AllowServiceLinkedRoles":       "Allow",
 		"DenyCreateRoleWithoutBoundary": "Deny",
 		"DenyBoundaryStripping":         "Deny",
 		"DenySelfModification":          "Deny",


### PR DESCRIPTION
Related to: https://app.clickup.com/t/868j06r6e

1. internal/handler/compute/role_policy_handler.go — Added iam:CreateServiceLinkedRole. Also added RolePolicyJSON() export for testing.                                                                                                    
2. internal/handler/compute/rolepolicy_test/role_policy_test.go (new) — tests validating the policy document structure, the new statement, and existing deny guards.