### PR TITLE
Fix storage-node permission gaps and tighten create/delete safety

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -54,6 +54,8 @@ var ErrInvalidOrganizationIdFormat = errors.New("invalid organization ID format 
 var ErrAccountNotRegistered = errors.New("account is not registered")
 var ErrBadRequest = errors.New("bad request")
 var ErrInvalidProviderType = errors.New("invalid provider type - must be s3, azure-blob, or local")
+var ErrInvalidDeploymentMode = errors.New("invalid deployment mode - must be basic or compliant")
+var ErrStorageNodeHasAttachments = errors.New("storage node has workspace attachments - detach them first or pass force=true to override")
 var ErrDeleteTagRequired = errors.New("bucket must have tag 'pennsieve:allow-delete' set to 'true' before deletion - set this tag on the S3 bucket in the AWS console to confirm")
 var ErrTooManySecrets = errors.New("too many secrets (max 50)")
 var ErrSecretKeyTooLong = errors.New("secret key exceeds max length (256)")

--- a/internal/handler/account/delete_account_handler.go
+++ b/internal/handler/account/delete_account_handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/pennsieve/account-service/internal/errors"
 	"github.com/pennsieve/account-service/internal/models"
+	"github.com/pennsieve/account-service/internal/service"
 	"github.com/pennsieve/account-service/internal/store_dynamodb"
 	"github.com/pennsieve/account-service/internal/utils"
 )
@@ -57,6 +58,8 @@ func DeleteAccountHandler(ctx context.Context, request events.APIGatewayV2HTTPRe
 	accountsTable := os.Getenv("ACCOUNTS_TABLE")
 	nodesTable := os.Getenv("COMPUTE_NODES_TABLE")
 	enablementTable := os.Getenv("ACCOUNT_WORKSPACE_TABLE")
+	storageNodesTable := os.Getenv("STORAGE_NODES_TABLE")
+	storageNodeWorkspaceTable := os.Getenv("STORAGE_NODE_WORKSPACE_TABLE")
 
 	accountsStore := &store_dynamodb.AccountDatabaseStore{
 		DB:        dynamoDBClient,
@@ -100,10 +103,26 @@ func DeleteAccountHandler(ctx context.Context, request events.APIGatewayV2HTTPRe
 	}
 
 	force := request.QueryStringParameters["force"]
-	if len(nodes) > 0 && force != "true" {
+
+	// Check for active storage nodes on this account
+	var storageNodes []models.DynamoDBStorageNode
+	if storageNodesTable != "" {
+		storageNodeStore := store_dynamodb.NewStorageNodeDatabaseStore(dynamoDBClient, storageNodesTable)
+		storageNodes, err = storageNodeStore.GetByAccount(ctx, uuid)
+		if err != nil {
+			log.Printf("error getting storage nodes for account %s: %v", uuid, err)
+			return events.APIGatewayV2HTTPResponse{
+				StatusCode: http.StatusInternalServerError,
+				Body:       errors.HandlerError(handlerName, errors.ErrDynamoDB),
+			}, nil
+		}
+	}
+
+	if (len(nodes) > 0 || len(storageNodes) > 0) && force != "true" {
 		body, _ := json.Marshal(map[string]interface{}{
-			"error":     fmt.Sprintf("account has %d active compute nodes", len(nodes)),
-			"nodeCount": len(nodes),
+			"error":            fmt.Sprintf("account has %d active compute nodes and %d active storage nodes", len(nodes), len(storageNodes)),
+			"nodeCount":        len(nodes),
+			"storageNodeCount": len(storageNodes),
 		})
 		return events.APIGatewayV2HTTPResponse{
 			StatusCode: http.StatusConflict,
@@ -121,6 +140,37 @@ func DeleteAccountHandler(ctx context.Context, request events.APIGatewayV2HTTPRe
 			if err := enablementStore.Delete(ctx, e.AccountUuid, e.WorkspaceId); err != nil {
 				log.Printf("warning: failed to delete workspace enablement %s/%s: %v", e.AccountUuid, e.WorkspaceId, err)
 			}
+		}
+	}
+
+	// Delete storage nodes (and their workspace attachments) so they don't linger in IAM policies.
+	// Provisioned buckets are NOT torn down here — the owner is expected to have cleaned those up first,
+	// or to pass force=true to accept that the records go away while the buckets remain.
+	if len(storageNodes) > 0 {
+		storageNodeStore := store_dynamodb.NewStorageNodeDatabaseStore(dynamoDBClient, storageNodesTable)
+		var wsStore store_dynamodb.StorageNodeWorkspaceStore
+		if storageNodeWorkspaceTable != "" {
+			wsStore = store_dynamodb.NewStorageNodeWorkspaceStore(dynamoDBClient, storageNodeWorkspaceTable)
+		}
+		for _, sn := range storageNodes {
+			if wsStore != nil {
+				attached, err := wsStore.GetByStorageNode(ctx, sn.Uuid)
+				if err != nil {
+					log.Printf("warning: failed to get storage node workspaces %s: %v", sn.Uuid, err)
+				}
+				for _, a := range attached {
+					if err := wsStore.Delete(ctx, a.StorageNodeUuid, a.WorkspaceId); err != nil {
+						log.Printf("warning: failed to delete storage node workspace %s/%s: %v", a.StorageNodeUuid, a.WorkspaceId, err)
+					}
+				}
+			}
+			if err := storageNodeStore.Delete(ctx, sn.Uuid); err != nil {
+				log.Printf("warning: failed to delete storage node %s: %v", sn.Uuid, err)
+			}
+		}
+		storagePolicyService := service.NewStoragePolicyService(cfg, storageNodeStore)
+		if err := storagePolicyService.RegenerateStoragePolicies(ctx); err != nil {
+			log.Printf("warning: failed to regenerate storage policies after account delete: %v", err)
 		}
 	}
 

--- a/internal/handler/storage/delete_storage_node_handler.go
+++ b/internal/handler/storage/delete_storage_node_handler.go
@@ -93,6 +93,33 @@ func DeleteStorageNodeHandler(ctx context.Context, request events.APIGatewayV2HT
 		}, nil
 	}
 
+	// Safety check: block delete if workspaces are still attached unless force=true.
+	// The caller should detach workspaces explicitly (or confirm the blast radius) before destroying the bucket.
+	force := request.QueryStringParameters["force"] == "true"
+	storageNodeWorkspaceTable := os.Getenv("STORAGE_NODE_WORKSPACE_TABLE")
+	var attachedWorkspaces []models.DynamoDBStorageNodeWorkspace
+	if storageNodeWorkspaceTable != "" {
+		wsStore := store_dynamodb.NewStorageNodeWorkspaceStore(dynamoDBClient, storageNodeWorkspaceTable)
+		attachedWorkspaces, err = wsStore.GetByStorageNode(ctx, nodeId)
+		if err != nil {
+			log.Printf("Error getting workspace associations: %v", err)
+			return events.APIGatewayV2HTTPResponse{
+				StatusCode: http.StatusInternalServerError,
+				Body:       errors.ComputeHandlerError(handlerName, errors.ErrDynamoDB),
+			}, nil
+		}
+		if len(attachedWorkspaces) > 0 && !force {
+			body, _ := json.Marshal(map[string]interface{}{
+				"error":           errors.ErrStorageNodeHasAttachments.Error(),
+				"attachmentCount": len(attachedWorkspaces),
+			})
+			return events.APIGatewayV2HTTPResponse{
+				StatusCode: http.StatusConflict,
+				Body:       string(body),
+			}, nil
+		}
+	}
+
 	// Safety check: for S3 nodes, require the bucket to have the
 	// "pennsieve:allow-delete" = "true" tag before proceeding.
 	// This forces the account owner to take a manual action in AWS
@@ -149,16 +176,13 @@ func DeleteStorageNodeHandler(ctx context.Context, request events.APIGatewayV2HT
 		}, nil
 	}
 
-	// Registration-only: delete workspace associations + DynamoDB record directly
-	storageNodeWorkspaceTable := os.Getenv("STORAGE_NODE_WORKSPACE_TABLE")
-	wsStore := store_dynamodb.NewStorageNodeWorkspaceStore(dynamoDBClient, storageNodeWorkspaceTable)
-	workspaces, err := wsStore.GetByStorageNode(ctx, nodeId)
-	if err != nil {
-		log.Printf("Error getting workspace associations: %v", err)
-	}
-	for _, ws := range workspaces {
-		if err := wsStore.Delete(ctx, ws.StorageNodeUuid, ws.WorkspaceId); err != nil {
-			log.Printf("Error deleting workspace association: %v", err)
+	// Registration-only: delete workspace associations (if force=true retained any) + DynamoDB record directly
+	if storageNodeWorkspaceTable != "" {
+		wsStore := store_dynamodb.NewStorageNodeWorkspaceStore(dynamoDBClient, storageNodeWorkspaceTable)
+		for _, ws := range attachedWorkspaces {
+			if err := wsStore.Delete(ctx, ws.StorageNodeUuid, ws.WorkspaceId); err != nil {
+				log.Printf("Error deleting workspace association: %v", err)
+			}
 		}
 	}
 

--- a/internal/handler/storage/get_storage_nodes_handler.go
+++ b/internal/handler/storage/get_storage_nodes_handler.go
@@ -115,20 +115,19 @@ func GetStorageNodesHandler(ctx context.Context, request events.APIGatewayV2HTTP
 	// For the list endpoint, only include the requesting user's workspace attachment
 	var responseNodes []models.StorageNode
 	for _, node := range storageNodes {
-		// Look up account info (cached)
+		// Look up account info (cached; cache failures too to avoid retry storms)
 		var accountName, accountOwnerId string
-		if _, cached := accountCache[node.AccountUuid]; !cached {
-			account, err := accountStore.GetById(ctx, node.AccountUuid)
+		acct, cached := accountCache[node.AccountUuid]
+		if !cached {
+			a, err := accountStore.GetById(ctx, node.AccountUuid)
 			if err != nil {
 				log.Printf("Error getting account %s: %v", node.AccountUuid, err)
-			} else {
-				accountCache[node.AccountUuid] = account
 			}
+			accountCache[node.AccountUuid] = a
+			acct = a
 		}
-		if acct, ok := accountCache[node.AccountUuid]; ok {
-			accountName = acct.Name
-			accountOwnerId = acct.UserId
-		}
+		accountName = acct.Name
+		accountOwnerId = acct.UserId
 
 		var wsEnablements []models.StorageNodeWorkspaceEnablement
 		if accountOwnerMode {

--- a/internal/handler/storage/helpers.go
+++ b/internal/handler/storage/helpers.go
@@ -42,6 +42,31 @@ func checkAdminManageAccess(ctx context.Context, cfg aws.Config, dynamoDBClient 
 	return isAdmin
 }
 
+// canAdminManageNode returns true if the user is an admin in at least one workspace
+// the storage node is attached to, where the account's enablement for that workspace
+// has IsPublic=true and EnableStorage=true. Use this for node-scoped admin gates when
+// the route does not receive a workspace context (token_auth).
+func canAdminManageNode(ctx context.Context, cfg aws.Config, dynamoDBClient *dynamodb.Client, userId, nodeUuid, accountUuid string) bool {
+	storageNodeWorkspaceTable := os.Getenv("STORAGE_NODE_WORKSPACE_TABLE")
+	if storageNodeWorkspaceTable == "" {
+		return false
+	}
+	wsStore := store_dynamodb.NewStorageNodeWorkspaceStore(dynamoDBClient, storageNodeWorkspaceTable)
+	attachments, err := wsStore.GetByStorageNode(ctx, nodeUuid)
+	if err != nil {
+		log.Printf("Error listing storage node workspaces for admin check: %v", err)
+		return false
+	}
+	for _, a := range attachments {
+		if checkAdminManageAccess(ctx, cfg, dynamoDBClient, userId, a.WorkspaceId, accountUuid) {
+			return true
+		}
+	}
+	return false
+}
+
+var validDeploymentModes = map[string]bool{"basic": true, "compliant": true}
+
 var s3BucketNameRegex = regexp.MustCompile(`^[a-z0-9][a-z0-9\-]{1,61}[a-z0-9]$`)
 var ipAddressRegex = regexp.MustCompile(`^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$`)
 

--- a/internal/handler/storage/impact_handler.go
+++ b/internal/handler/storage/impact_handler.go
@@ -79,7 +79,7 @@ func GetDetachImpactHandler(ctx context.Context, request events.APIGatewayV2HTTP
 
 	hasAccess := account.UserId == userId
 	if !hasAccess {
-		hasAccess = checkAdminManageAccess(ctx, cfg, dynamoDBClient, userId, claims.OrgClaim.NodeId, node.AccountUuid)
+		hasAccess = canAdminManageNode(ctx, cfg, dynamoDBClient, userId, node.Uuid, node.AccountUuid)
 	}
 	if !hasAccess {
 		return events.APIGatewayV2HTTPResponse{

--- a/internal/handler/storage/patch_storage_node_handler.go
+++ b/internal/handler/storage/patch_storage_node_handler.go
@@ -99,7 +99,7 @@ func PatchStorageNodeHandler(ctx context.Context, request events.APIGatewayV2HTT
 
 	canUpdate = account.UserId == userId
 	if !canUpdate {
-		canUpdate = checkAdminManageAccess(ctx, cfg, dynamoDBClient, userId, claims.OrgClaim.NodeId, node.AccountUuid)
+		canUpdate = canAdminManageNode(ctx, cfg, dynamoDBClient, userId, node.Uuid, node.AccountUuid)
 	}
 	if !canUpdate {
 		return events.APIGatewayV2HTTPResponse{

--- a/internal/handler/storage/post_storage_node_handler.go
+++ b/internal/handler/storage/post_storage_node_handler.go
@@ -40,14 +40,14 @@ func PostStorageNodeHandler(ctx context.Context, request events.APIGatewayV2HTTP
 		}, nil
 	}
 
-	if req.AccountUuid == "" || req.OrganizationId == "" || req.Name == "" || req.StorageLocation == "" || req.ProviderType == "" {
+	if req.AccountUuid == "" || req.Name == "" || req.StorageLocation == "" || req.ProviderType == "" {
 		return events.APIGatewayV2HTTPResponse{
 			StatusCode: http.StatusBadRequest,
 			Body:       errors.ComputeHandlerError(handlerName, errors.ErrBadRequest),
 		}, nil
 	}
 
-	if !strings.HasPrefix(req.OrganizationId, "N:organization:") {
+	if req.OrganizationId != "" && !strings.HasPrefix(req.OrganizationId, "N:organization:") {
 		return events.APIGatewayV2HTTPResponse{
 			StatusCode: http.StatusBadRequest,
 			Body:       errors.ComputeHandlerError(handlerName, errors.ErrInvalidOrganizationIdFormat),
@@ -59,6 +59,13 @@ func PostStorageNodeHandler(ctx context.Context, request events.APIGatewayV2HTTP
 		return events.APIGatewayV2HTTPResponse{
 			StatusCode: http.StatusBadRequest,
 			Body:       errors.ComputeHandlerError(handlerName, errors.ErrInvalidProviderType),
+		}, nil
+	}
+
+	if req.DeploymentMode != "" && !validDeploymentModes[req.DeploymentMode] {
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: http.StatusBadRequest,
+			Body:       errors.ComputeHandlerError(handlerName, errors.ErrInvalidDeploymentMode),
 		}, nil
 	}
 
@@ -74,7 +81,6 @@ func PostStorageNodeHandler(ctx context.Context, request events.APIGatewayV2HTTP
 
 	claims := authorizer.ParseClaims(request.RequestContext.Authorizer.Lambda)
 	userId := claims.UserClaim.NodeId
-	organizationId := claims.OrgClaim.NodeId
 
 	cfg, err := utils.LoadAWSConfig(ctx)
 	if err != nil {
@@ -105,53 +111,62 @@ func PostStorageNodeHandler(ctx context.Context, request events.APIGatewayV2HTTP
 		}, nil
 	}
 
-	// Check workspace enablement
-	enablementTable := os.Getenv("ACCOUNT_WORKSPACE_TABLE")
-	if enablementTable == "" {
-		log.Printf("ACCOUNT_WORKSPACE_TABLE not configured")
-		return events.APIGatewayV2HTTPResponse{
-			StatusCode: http.StatusInternalServerError,
-			Body:       errors.ComputeHandlerError(handlerName, errors.ErrConfig),
-		}, nil
-	}
-
-	workspaceStore := store_dynamodb.NewAccountWorkspaceStore(dynamoDBClient, enablementTable)
-	enablement, err := workspaceStore.Get(ctx, req.AccountUuid, req.OrganizationId)
-	if err != nil {
-		log.Printf("Error getting workspace enablement: %v", err)
-		return events.APIGatewayV2HTTPResponse{
-			StatusCode: http.StatusInternalServerError,
-			Body:       errors.ComputeHandlerError(handlerName, errors.ErrDynamoDB),
-		}, nil
-	}
-	if enablement.AccountUuid == "" || enablement.WorkspaceId == "" {
-		log.Printf("Account %s is not enabled for workspace %s", req.AccountUuid, req.OrganizationId)
-		return events.APIGatewayV2HTTPResponse{
-			StatusCode: http.StatusForbidden,
-			Body:       errors.ComputeHandlerError(handlerName, errors.ErrAccountNotEnabledForWorkspace),
-		}, nil
-	}
-
-	// Check permissions: account owner can always create; admins need isPublic + enableStorage
-	if account.UserId != userId {
-		if !enablement.IsPublic {
+	// When organizationId is omitted, only the account owner can create a node
+	// (no workspace context, so enablement and admin-on-public paths don't apply).
+	if req.OrganizationId == "" {
+		if account.UserId != userId {
 			return events.APIGatewayV2HTTPResponse{
 				StatusCode: http.StatusForbidden,
 				Body:       errors.ComputeHandlerError(handlerName, errors.ErrOnlyAccountOwnerCanCreateNodes),
 			}, nil
 		}
-		if !enablement.EnableStorage {
+	} else {
+		enablementTable := os.Getenv("ACCOUNT_WORKSPACE_TABLE")
+		if enablementTable == "" {
+			log.Printf("ACCOUNT_WORKSPACE_TABLE not configured")
 			return events.APIGatewayV2HTTPResponse{
-				StatusCode: http.StatusForbidden,
-				Body:       errors.ComputeHandlerError(handlerName, errors.ErrStorageNotEnabledForWorkspace),
+				StatusCode: http.StatusInternalServerError,
+				Body:       errors.ComputeHandlerError(handlerName, errors.ErrConfig),
 			}, nil
 		}
-		canCreate := checkAdminManageAccess(ctx, cfg, dynamoDBClient, userId, organizationId, req.AccountUuid)
-		if !canCreate {
+
+		workspaceStore := store_dynamodb.NewAccountWorkspaceStore(dynamoDBClient, enablementTable)
+		enablement, err := workspaceStore.Get(ctx, req.AccountUuid, req.OrganizationId)
+		if err != nil {
+			log.Printf("Error getting workspace enablement: %v", err)
+			return events.APIGatewayV2HTTPResponse{
+				StatusCode: http.StatusInternalServerError,
+				Body:       errors.ComputeHandlerError(handlerName, errors.ErrDynamoDB),
+			}, nil
+		}
+		if enablement.AccountUuid == "" || enablement.WorkspaceId == "" {
+			log.Printf("Account %s is not enabled for workspace %s", req.AccountUuid, req.OrganizationId)
 			return events.APIGatewayV2HTTPResponse{
 				StatusCode: http.StatusForbidden,
-				Body:       errors.ComputeHandlerError(handlerName, errors.ErrForbidden),
+				Body:       errors.ComputeHandlerError(handlerName, errors.ErrAccountNotEnabledForWorkspace),
 			}, nil
+		}
+
+		if account.UserId != userId {
+			if !enablement.IsPublic {
+				return events.APIGatewayV2HTTPResponse{
+					StatusCode: http.StatusForbidden,
+					Body:       errors.ComputeHandlerError(handlerName, errors.ErrOnlyAccountOwnerCanCreateNodes),
+				}, nil
+			}
+			if !enablement.EnableStorage {
+				return events.APIGatewayV2HTTPResponse{
+					StatusCode: http.StatusForbidden,
+					Body:       errors.ComputeHandlerError(handlerName, errors.ErrStorageNotEnabledForWorkspace),
+				}, nil
+			}
+			canCreate := checkAdminManageAccess(ctx, cfg, dynamoDBClient, userId, req.OrganizationId, req.AccountUuid)
+			if !canCreate {
+				return events.APIGatewayV2HTTPResponse{
+					StatusCode: http.StatusForbidden,
+					Body:       errors.ComputeHandlerError(handlerName, errors.ErrForbidden),
+				}, nil
+			}
 		}
 	}
 
@@ -196,9 +211,10 @@ func PostStorageNodeHandler(ctx context.Context, request events.APIGatewayV2HTTP
 	}
 	log.Printf("Created storage node %s in DynamoDB with status %s", nodeUuid, initialStatus)
 
-	// Auto-attach storage node to the workspace it was created in
+	// Auto-attach storage node to the workspace it was created in. If this fails we
+	// roll back the node record so the caller can retry cleanly.
 	storageNodeWorkspaceTable := os.Getenv("STORAGE_NODE_WORKSPACE_TABLE")
-	if storageNodeWorkspaceTable != "" {
+	if req.OrganizationId != "" && storageNodeWorkspaceTable != "" {
 		wsStore := store_dynamodb.NewStorageNodeWorkspaceStore(dynamoDBClient, storageNodeWorkspaceTable)
 		autoAttachment := models.DynamoDBStorageNodeWorkspace{
 			StorageNodeUuid: nodeUuid,
@@ -208,7 +224,14 @@ func PostStorageNodeHandler(ctx context.Context, request events.APIGatewayV2HTTP
 			EnabledAt:       time.Now().UTC().Format(time.RFC3339),
 		}
 		if err := wsStore.Insert(ctx, autoAttachment); err != nil {
-			log.Printf("Warning: Failed to auto-attach storage node to workspace: %v", err)
+			log.Printf("Error auto-attaching storage node to workspace, rolling back node %s: %v", nodeUuid, err)
+			if delErr := storageNodeStore.Delete(ctx, nodeUuid); delErr != nil {
+				log.Printf("Error rolling back storage node %s: %v", nodeUuid, delErr)
+			}
+			return events.APIGatewayV2HTTPResponse{
+				StatusCode: http.StatusInternalServerError,
+				Body:       errors.ComputeHandlerError(handlerName, errors.ErrDynamoDB),
+			}, nil
 		}
 	}
 

--- a/internal/handler/storage/storage_handler_test.go
+++ b/internal/handler/storage/storage_handler_test.go
@@ -288,27 +288,70 @@ func TestPostStorageNodeHandler_NoEnablement(t *testing.T) {
 	assert.Contains(t, response.Body, "not enabled for this workspace")
 }
 
-func TestPostStorageNodeHandler_MissingOrganizationId(t *testing.T) {
-	_, _, _ = setupStorageHandlerTest(t)
+func TestPostStorageNodeHandler_NoOrganizationId_OwnerSucceeds(t *testing.T) {
+	accountStore, storageNodeStore, wsStore := setupStorageHandlerTest(t)
 	ctx := context.Background()
+	userId := "user-" + test.GenerateTestId()
+	testAccount := createTestAccount(t, accountStore, userId)
 
 	reqBody, _ := json.Marshal(models.CreateStorageNodeRequest{
-		AccountUuid:     uuid.New().String(),
-		Name:            "Test Storage",
-		StorageLocation: "some-bucket",
-		ProviderType:    "s3",
+		AccountUuid:      testAccount.Uuid,
+		Name:             "Platform Default Storage",
+		StorageLocation:  "pennsieve-prod-storage-use1",
+		Region:           "us-east-1",
+		ProviderType:     "s3",
+		SkipProvisioning: true,
 	})
 
 	request := events.APIGatewayV2HTTPRequest{
 		Body: string(reqBody),
 		RequestContext: events.APIGatewayV2HTTPRequestContext{
-			Authorizer: test.CreateTestAuthorizer("test-user", testOrgId),
+			Authorizer: test.CreateTestAuthorizer(userId, testOrgId),
 		},
 	}
 
 	response, err := storage.PostStorageNodeHandler(ctx, request)
 	assert.NoError(t, err)
-	assert.Equal(t, 400, response.StatusCode)
+	assert.Equal(t, 201, response.StatusCode)
+
+	// Parse the response to get the node UUID, then verify no auto-attach happened.
+	var created models.StorageNode
+	require.NoError(t, json.Unmarshal([]byte(response.Body), &created))
+
+	node, err := storageNodeStore.GetById(ctx, created.Uuid)
+	require.NoError(t, err)
+	assert.Equal(t, testAccount.Uuid, node.AccountUuid)
+
+	attachments, err := wsStore.GetByStorageNode(ctx, created.Uuid)
+	require.NoError(t, err)
+	assert.Empty(t, attachments, "no workspace auto-attach when organizationId is omitted")
+}
+
+func TestPostStorageNodeHandler_NoOrganizationId_NonOwnerForbidden(t *testing.T) {
+	accountStore, _, _ := setupStorageHandlerTest(t)
+	ctx := context.Background()
+	ownerId := "user-" + test.GenerateTestId()
+	callerId := "user-" + test.GenerateTestId()
+	testAccount := createTestAccount(t, accountStore, ownerId)
+
+	reqBody, _ := json.Marshal(models.CreateStorageNodeRequest{
+		AccountUuid:      testAccount.Uuid,
+		Name:             "Test Storage",
+		StorageLocation:  "some-bucket",
+		ProviderType:     "s3",
+		SkipProvisioning: true,
+	})
+
+	request := events.APIGatewayV2HTTPRequest{
+		Body: string(reqBody),
+		RequestContext: events.APIGatewayV2HTTPRequestContext{
+			Authorizer: test.CreateTestAuthorizer(callerId, testOrgId),
+		},
+	}
+
+	response, err := storage.PostStorageNodeHandler(ctx, request)
+	assert.NoError(t, err)
+	assert.Equal(t, 403, response.StatusCode)
 }
 
 func TestPostStorageNodeHandler_OwnerBypassesEnableStorage(t *testing.T) {

--- a/internal/handler/storage/update_config_handler.go
+++ b/internal/handler/storage/update_config_handler.go
@@ -82,7 +82,7 @@ func PostUpdateConfigHandler(ctx context.Context, request events.APIGatewayV2HTT
 
 	canUpdate := account.UserId == userId
 	if !canUpdate {
-		canUpdate = checkAdminManageAccess(ctx, cfg, dynamoDBClient, userId, claims.OrgClaim.NodeId, node.AccountUuid)
+		canUpdate = canAdminManageNode(ctx, cfg, dynamoDBClient, userId, node.Uuid, node.AccountUuid)
 	}
 	if !canUpdate {
 		return events.APIGatewayV2HTTPResponse{

--- a/internal/models/storage_node.go
+++ b/internal/models/storage_node.go
@@ -8,7 +8,7 @@ import (
 // CreateStorageNodeRequest is the request body for POST /storage-nodes
 type CreateStorageNodeRequest struct {
 	AccountUuid      string `json:"accountUuid"`
-	OrganizationId   string `json:"organizationId"`             // Required: workspace for this storage node
+	OrganizationId   string `json:"organizationId,omitempty"`   // Optional: if set, checks workspace enablement and auto-attaches the node to that workspace
 	Name             string `json:"name"`
 	Description      string `json:"description"`
 	StorageLocation  string `json:"storageLocation"`

--- a/terraform/accounts-service.yml
+++ b/terraform/accounts-service.yml
@@ -2033,7 +2033,6 @@ paths:
               type: object
               required:
                 - accountUuid
-                - organizationId
                 - name
                 - storageLocation
                 - providerType
@@ -2042,7 +2041,13 @@ paths:
                   type: string
                 organizationId:
                   type: string
-                  description: Organization ID (workspace) for this storage node
+                  description: |
+                    Optional workspace for this storage node. When provided, the account must be
+                    enabled for the workspace, the caller must be the account owner or a workspace
+                    admin on a public+storage-enabled account, and the node is auto-attached to
+                    that workspace. When omitted, only the account owner may create the node and
+                    no workspace attachment is created (workspaces can be attached afterwards via
+                    POST /storage-nodes/{id}/workspace).
                   example: "N:organization:050fae39-4412-43ef-a514-703ed8e299d5"
                 name:
                   type: string


### PR DESCRIPTION
## Summary

- **`POST /storage-nodes`**: `organizationId` is now optional so an account owner can register a bucket (e.g. the legacy platform-default bucket) without binding it to a single workspace. When provided, behavior is unchanged (enablement check + auto-attach). Admin path also fixed — `checkAdminManageAccess` now targets `req.OrganizationId` rather than the caller's session org.
- **Admin-check bug in PATCH, update-config, impact handlers**: all three were passing `claims.OrgClaim.NodeId` (the caller's session workspace from `token_auth`) into `checkAdminManageAccess`. Replaced with a new `canAdminManageNode` helper that iterates the node's attached workspaces and verifies admin+IsPublic+EnableStorage there.
- **Safety / correctness**:
  - Validate `deploymentMode` against `basic`/`compliant`.
  - Roll back the node record when auto-attach fails instead of returning 201 with a warning log.
  - `DELETE /storage-nodes/{id}` returns 409 with attachment count when workspaces are still attached unless `?force=true` (prevents silently breaking the 178-org default bucket).
  - `DELETE /accounts/{id}` now also checks for active storage nodes (parallel to the existing compute-node check) and, on force-delete, cascades cleanup of storage nodes + workspace attachments + regenerates the managed IAM policies.
  - Fix retry-storm in `GetStorageNodesHandler` account cache (failed lookups are now cached).

## Background

`POST /storage-nodes` had started requiring `organizationId` in commit `03c8319` ("make user experience for storage nodes the same as compute nodes"), which blocks the seed pattern we used successfully in dev — and more importantly doesn't fit the legacy platform-default bucket shared across 178 prod workspaces. While auditing that fix, several adjacent permission and safety bugs surfaced; they're bundled here.

## Test plan

- [x] `make test` — full suite green, including two new tests: owner-can-create-without-organizationId (no auto-attach happens) and non-owner-forbidden-without-organizationId.
- [ ] Deploy to dev and confirm existing storage nodes still work.
- [ ] Re-run `scripts/seed-storage-nodes.sh` shape against dev (should be a no-op if already seeded) to verify POST still accepts both the with-org and without-org payloads.
- [ ] Deploy to prod and run `seed-storage-nodes-prod.sh`.
- [ ] Verify the managed IAM policies (`{env}-storage-bucket-read`/`-write`) include the registered buckets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)