### PR TITLE
fix: adds lambda ECR access

### DIFF
--- a/internal/ecr/policy.go
+++ b/internal/ecr/policy.go
@@ -11,7 +11,11 @@ import (
 	ecrTypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
 )
 
-const appStorePolicySid = "AllowCrossAccountPull"
+const (
+	appStorePolicySid       = "AllowCrossAccountPull"
+	appStoreLambdaPolicySid = "AllowLambdaCrossAccountPull"
+	lambdaServicePrincipal  = "lambda.amazonaws.com"
+)
 
 // PolicyDocument represents an ECR repository policy.
 type PolicyDocument struct {
@@ -25,37 +29,74 @@ type PolicyStatement struct {
 	Effect    string          `json:"Effect"`
 	Principal PolicyPrincipal `json:"Principal"`
 	Action    []string        `json:"Action"`
+	Condition PolicyCondition `json:"Condition,omitempty"`
+}
+
+// PolicyCondition models the optional Condition block of a policy statement.
+// Outer key is the operator (e.g. "StringLike"); inner key is the condition
+// key (e.g. "aws:sourceArn"); value is a string-or-array list.
+type PolicyCondition map[string]map[string]ConditionValues
+
+// ConditionValues holds a string-or-array policy condition value.
+type ConditionValues []string
+
+func (c *ConditionValues) UnmarshalJSON(data []byte) error {
+	vals, err := decodeStringOrArray(data)
+	if err != nil {
+		return err
+	}
+	*c = vals
+	return nil
 }
 
 // PolicyPrincipal represents the principal block in a policy statement.
-// AWS may return the AWS field as a single string or as an array of strings,
+// AWS may return AWS/Service fields as a single string or array of strings,
 // so we use a custom unmarshaler to handle both forms.
 type PolicyPrincipal struct {
-	AWS []string `json:"AWS"`
+	AWS     []string `json:"AWS,omitempty"`
+	Service []string `json:"Service,omitempty"`
 }
 
 func (p *PolicyPrincipal) UnmarshalJSON(data []byte) error {
 	var raw struct {
-		AWS json.RawMessage `json:"AWS"`
+		AWS     json.RawMessage `json:"AWS"`
+		Service json.RawMessage `json:"Service"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
-	if len(raw.AWS) == 0 {
-		p.AWS = []string{}
-		return nil
-	}
-	// Try array first
-	if raw.AWS[0] == '[' {
-		return json.Unmarshal(raw.AWS, &p.AWS)
-	}
-	// Single string
-	var single string
-	if err := json.Unmarshal(raw.AWS, &single); err != nil {
+	awsVals, err := decodeStringOrArray(raw.AWS)
+	if err != nil {
 		return err
 	}
-	p.AWS = []string{single}
+	svcVals, err := decodeStringOrArray(raw.Service)
+	if err != nil {
+		return err
+	}
+	if awsVals == nil {
+		awsVals = []string{}
+	}
+	p.AWS = awsVals
+	p.Service = svcVals
 	return nil
+}
+
+func decodeStringOrArray(data json.RawMessage) ([]string, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	if data[0] == '[' {
+		var arr []string
+		if err := json.Unmarshal(data, &arr); err != nil {
+			return nil, err
+		}
+		return arr, nil
+	}
+	var single string
+	if err := json.Unmarshal(data, &single); err != nil {
+		return nil, err
+	}
+	return []string{single}, nil
 }
 
 // AppStorePolicy manages cross-account pull access on an ECR repository.
@@ -78,10 +119,18 @@ func NewAppStorePolicy(client *ecr.Client, repoName string) AppStorePolicy {
 const maxRetries = 3
 
 // EnsureAccess adds the given AWS account as a cross-account pull principal
-// on the repository policy. It is a no-op if the account already has access.
-// It retries if a concurrent update overwrites the principal (read-modify-write race).
+// on the repository policy and grants the Lambda service principal permission
+// to pull images for Lambda functions in that account. It is a no-op if both
+// entries are already present, and retries if a concurrent update overwrites
+// them (read-modify-write race).
+//
+// Lambda's CreateFunction/UpdateFunctionCode pulls the image using the
+// lambda.amazonaws.com service principal, not the caller's IAM role, so the
+// account-root principal alone is not sufficient for cross-account image
+// references. See: https://docs.aws.amazon.com/lambda/latest/dg/images-create.html#images-permissions
 func (p *appStorePolicy) EnsureAccess(ctx context.Context, accountId string) error {
 	principal := fmt.Sprintf("arn:aws:iam::%s:root", accountId)
+	sourceArn := LambdaSourceArn(accountId)
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
 		policy, err := p.getPolicy(ctx)
@@ -89,11 +138,15 @@ func (p *appStorePolicy) EnsureAccess(ctx context.Context, accountId string) err
 			return fmt.Errorf("error getting ECR repository policy: %w", err)
 		}
 
-		if ContainsPrincipal(policy, principal) {
+		if ContainsPrincipal(policy, principal) && ContainsLambdaSourceArn(policy, sourceArn) {
 			return nil
 		}
-
-		AddPrincipal(&policy, principal)
+		if !ContainsPrincipal(policy, principal) {
+			AddPrincipal(&policy, principal)
+		}
+		if !ContainsLambdaSourceArn(policy, sourceArn) {
+			AddLambdaSourceArn(&policy, sourceArn)
+		}
 
 		policyJSON, err := json.Marshal(policy)
 		if err != nil {
@@ -108,18 +161,18 @@ func (p *appStorePolicy) EnsureAccess(ctx context.Context, accountId string) err
 			return fmt.Errorf("error setting ECR repository policy: %w", err)
 		}
 
-		// Re-read the policy to verify our principal survived (another writer may have overwritten it).
+		// Re-read the policy to verify our entries survived (another writer may have overwritten them).
 		policy, err = p.getPolicy(ctx)
 		if err != nil {
 			return fmt.Errorf("error verifying ECR repository policy: %w", err)
 		}
 
-		if ContainsPrincipal(policy, principal) {
+		if ContainsPrincipal(policy, principal) && ContainsLambdaSourceArn(policy, sourceArn) {
 			return nil
 		}
 	}
 
-	return fmt.Errorf("failed to add principal %s to ECR policy after %d retries: concurrent modification", principal, maxRetries)
+	return fmt.Errorf("failed to add principal %s or lambda source arn %s to ECR policy after %d retries: concurrent modification", principal, sourceArn, maxRetries)
 }
 
 func (p *appStorePolicy) getPolicy(ctx context.Context) (PolicyDocument, error) {
@@ -198,6 +251,65 @@ func AddPrincipal(policy *PolicyDocument, principal string) {
 			"ecr:GetDownloadUrlForLayer",
 			"ecr:BatchGetImage",
 			"ecr:BatchCheckLayerAvailability",
+		},
+	})
+}
+
+// LambdaSourceArn returns the aws:sourceArn pattern used to scope Lambda
+// service-principal access to Lambda functions in the given account.
+func LambdaSourceArn(accountId string) string {
+	return fmt.Sprintf("arn:aws:lambda:*:%s:function:*", accountId)
+}
+
+// ContainsLambdaSourceArn reports whether the policy's Lambda service-principal
+// statement already includes the given aws:sourceArn entry.
+func ContainsLambdaSourceArn(policy PolicyDocument, sourceArn string) bool {
+	for _, stmt := range policy.Statement {
+		if stmt.Sid != appStoreLambdaPolicySid {
+			continue
+		}
+		for _, arn := range stmt.Condition["StringLike"]["aws:sourceArn"] {
+			if arn == sourceArn {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// AddLambdaSourceArn appends a sourceArn pattern to the Lambda service-principal
+// statement's StringLike/aws:sourceArn condition. If the statement does not
+// exist, a new one is created.
+func AddLambdaSourceArn(policy *PolicyDocument, sourceArn string) {
+	for i, stmt := range policy.Statement {
+		if stmt.Sid != appStoreLambdaPolicySid {
+			continue
+		}
+		if policy.Statement[i].Condition == nil {
+			policy.Statement[i].Condition = PolicyCondition{}
+		}
+		if policy.Statement[i].Condition["StringLike"] == nil {
+			policy.Statement[i].Condition["StringLike"] = map[string]ConditionValues{}
+		}
+		policy.Statement[i].Condition["StringLike"]["aws:sourceArn"] = append(
+			policy.Statement[i].Condition["StringLike"]["aws:sourceArn"], sourceArn,
+		)
+		return
+	}
+	policy.Statement = append(policy.Statement, PolicyStatement{
+		Sid:    appStoreLambdaPolicySid,
+		Effect: "Allow",
+		Principal: PolicyPrincipal{
+			Service: []string{lambdaServicePrincipal},
+		},
+		Action: []string{
+			"ecr:GetDownloadUrlForLayer",
+			"ecr:BatchGetImage",
+		},
+		Condition: PolicyCondition{
+			"StringLike": {
+				"aws:sourceArn": ConditionValues{sourceArn},
+			},
 		},
 	})
 }

--- a/internal/ecr/policy_test.go
+++ b/internal/ecr/policy_test.go
@@ -97,3 +97,129 @@ func TestAddPrincipal_CreatesStatementIfMissing(t *testing.T) {
 	assert.Equal(t, appStorePolicySid, policy.Statement[0].Sid)
 	assert.Equal(t, []string{"arn:aws:iam::111111111111:root"}, policy.Statement[0].Principal.AWS)
 }
+
+func TestLambdaSourceArn(t *testing.T) {
+	assert.Equal(t, "arn:aws:lambda:*:111111111111:function:*", LambdaSourceArn("111111111111"))
+}
+
+func TestContainsLambdaSourceArn(t *testing.T) {
+	var policy PolicyDocument
+	AddLambdaSourceArn(&policy, LambdaSourceArn("111111111111"))
+	AddLambdaSourceArn(&policy, LambdaSourceArn("222222222222"))
+
+	assert.True(t, ContainsLambdaSourceArn(policy, LambdaSourceArn("111111111111")))
+	assert.True(t, ContainsLambdaSourceArn(policy, LambdaSourceArn("222222222222")))
+	assert.False(t, ContainsLambdaSourceArn(policy, LambdaSourceArn("333333333333")))
+}
+
+func TestContainsLambdaSourceArn_EmptyPolicy(t *testing.T) {
+	var policy PolicyDocument
+	assert.False(t, ContainsLambdaSourceArn(policy, LambdaSourceArn("111111111111")))
+}
+
+func TestAddLambdaSourceArn_CreatesStatementIfMissing(t *testing.T) {
+	var policy PolicyDocument
+
+	AddLambdaSourceArn(&policy, LambdaSourceArn("111111111111"))
+
+	assert.Len(t, policy.Statement, 1)
+	stmt := policy.Statement[0]
+	assert.Equal(t, appStoreLambdaPolicySid, stmt.Sid)
+	assert.Equal(t, "Allow", stmt.Effect)
+	assert.Equal(t, []string{lambdaServicePrincipal}, stmt.Principal.Service)
+	assert.Empty(t, stmt.Principal.AWS)
+	assert.Equal(t,
+		ConditionValues{"arn:aws:lambda:*:111111111111:function:*"},
+		stmt.Condition["StringLike"]["aws:sourceArn"],
+	)
+}
+
+func TestAddLambdaSourceArn_AppendsToExistingStatement(t *testing.T) {
+	var policy PolicyDocument
+	AddLambdaSourceArn(&policy, LambdaSourceArn("111111111111"))
+	AddLambdaSourceArn(&policy, LambdaSourceArn("222222222222"))
+
+	assert.Len(t, policy.Statement, 1)
+	assert.Equal(t,
+		ConditionValues{
+			"arn:aws:lambda:*:111111111111:function:*",
+			"arn:aws:lambda:*:222222222222:function:*",
+		},
+		policy.Statement[0].Condition["StringLike"]["aws:sourceArn"],
+	)
+}
+
+func TestAddLambdaSourceArn_CoexistsWithAWSPrincipalStatement(t *testing.T) {
+	policy := NewPullPolicy([]string{"arn:aws:iam::111111111111:root"})
+
+	AddLambdaSourceArn(&policy, LambdaSourceArn("111111111111"))
+
+	assert.Len(t, policy.Statement, 2)
+	assert.Equal(t, appStorePolicySid, policy.Statement[0].Sid)
+	assert.Equal(t, appStoreLambdaPolicySid, policy.Statement[1].Sid)
+}
+
+func TestPolicy_RoundtripWithLambdaStatement(t *testing.T) {
+	original := NewPullPolicy([]string{"arn:aws:iam::111111111111:root"})
+	AddLambdaSourceArn(&original, LambdaSourceArn("111111111111"))
+
+	data, err := json.Marshal(original)
+	assert.NoError(t, err)
+
+	var got PolicyDocument
+	assert.NoError(t, json.Unmarshal(data, &got))
+
+	assert.True(t, ContainsPrincipal(got, "arn:aws:iam::111111111111:root"))
+	assert.True(t, ContainsLambdaSourceArn(got, LambdaSourceArn("111111111111")))
+
+	// The Lambda statement's Principal must serialize as Service-only (no empty AWS field).
+	assert.NotContains(t, string(data), `"AWS":[]`)
+	assert.Contains(t, string(data), `"Service":["lambda.amazonaws.com"]`)
+}
+
+func TestPolicyPrincipal_UnmarshalJSON_ServiceSingleString(t *testing.T) {
+	policyJSON := `{
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Sid": "AllowLambdaCrossAccountPull",
+			"Effect": "Allow",
+			"Principal": {"Service": "lambda.amazonaws.com"},
+			"Action": ["ecr:BatchGetImage"],
+			"Condition": {"StringLike": {"aws:sourceArn": "arn:aws:lambda:*:111111111111:function:*"}}
+		}]
+	}`
+
+	var policy PolicyDocument
+	err := json.Unmarshal([]byte(policyJSON), &policy)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"lambda.amazonaws.com"}, policy.Statement[0].Principal.Service)
+	assert.Equal(t,
+		ConditionValues{"arn:aws:lambda:*:111111111111:function:*"},
+		policy.Statement[0].Condition["StringLike"]["aws:sourceArn"],
+	)
+}
+
+func TestPolicyPrincipal_UnmarshalJSON_ServiceArray(t *testing.T) {
+	policyJSON := `{
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Sid": "AllowLambdaCrossAccountPull",
+			"Effect": "Allow",
+			"Principal": {"Service": ["lambda.amazonaws.com"]},
+			"Action": ["ecr:BatchGetImage"],
+			"Condition": {"StringLike": {"aws:sourceArn": ["arn:aws:lambda:*:111111111111:function:*", "arn:aws:lambda:*:222222222222:function:*"]}}
+		}]
+	}`
+
+	var policy PolicyDocument
+	err := json.Unmarshal([]byte(policyJSON), &policy)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"lambda.amazonaws.com"}, policy.Statement[0].Principal.Service)
+	assert.Equal(t,
+		ConditionValues{
+			"arn:aws:lambda:*:111111111111:function:*",
+			"arn:aws:lambda:*:222222222222:function:*",
+		},
+		policy.Statement[0].Condition["StringLike"]["aws:sourceArn"],
+	)
+}


### PR DESCRIPTION
Related: https://app.clickup.com/t/868jjg6jn

**Problem**: _Cross-account Lambda CreateFunction against the app-store ECR repo failed with AccessDeniedException. Account-root principal alone isn't enough; Lambda's image pull is
  performed by the lambda.amazonaws.com service principal, which the repo policy didn't permit._

  Fix (internal/ecr/policy.go):
  - New AllowLambdaCrossAccountPull statement managed alongside the existing AllowCrossAccountPull — Service: lambda.amazonaws.com, actions BatchGetImage/GetDownloadUrlForLayer,
  scoped via StringLike aws:sourceArn = arn:aws:lambda:*:<acct>:function:*.
  - EnsureAccess now ensures both statements per call; idempotent and retry-safe.
  - Helpers: LambdaSourceArn, ContainsLambdaSourceArn, AddLambdaSourceArn.
  - PolicyPrincipal gained Service (string-or-array), PolicyStatement gained optional Condition (PolicyCondition / ConditionValues).

  Tests (internal/ecr/policy_test.go): 9 new tests covering source-arn build, contains/add (create + append), coexistence with the AWS-principal statement, JSON roundtrip (no empty
  "AWS":[] on Lambda statement), and Service unmarshaling from both string and array forms.