### PR TITLE
chat quotas: surface dailyTokens / monthlyTokens on /effective

### DIFF
--- a/internal/handler/compute/chat_quota_handlers.go
+++ b/internal/handler/compute/chat_quota_handlers.go
@@ -503,6 +503,13 @@ type effectiveQuotaResponse struct {
 	// re-doing it.
 	RemainingDayUsd   float64 `json:"remainingDayUsd"`
 	RemainingMonthUsd float64 `json:"remainingMonthUsd"`
+
+	// Token counts for the same buckets. Tracked alongside cost so frontends
+	// can display a less in-your-face "tokens used" caption instead of
+	// dollars while keeping the dollar-based enforcement axis intact.
+	// Total = input + output across all turns in the period.
+	DailyTokens   int64 `json:"dailyTokens"`
+	MonthlyTokens int64 `json:"monthlyTokens"`
 }
 
 // GetChatUserEffectiveQuotaHandler returns the resolved limits + current
@@ -618,6 +625,8 @@ func GetChatUserEffectiveQuotaHandler(ctx context.Context, request events.APIGat
 	resp.MonthlySpentUsd = monthly.EstimatedCostUsd
 	resp.RemainingDayUsd = maxFloat(0, resp.DailyCostUsd-resp.DailySpentUsd)
 	resp.RemainingMonthUsd = maxFloat(0, resp.MonthlyCostUsd-resp.MonthlySpentUsd)
+	resp.DailyTokens = daily.TotalInputTokens + daily.TotalOutputTokens
+	resp.MonthlyTokens = monthly.TotalInputTokens + monthly.TotalOutputTokens
 
 	out, _ := json.Marshal(resp)
 	return events.APIGatewayV2HTTPResponse{

--- a/terraform/accounts-service.yml
+++ b/terraform/accounts-service.yml
@@ -647,6 +647,20 @@ components:
           type: number
           format: double
           description: max(0, monthlyCostUsd - monthlySpentUsd).
+        dailyTokens:
+          type: integer
+          format: int64
+          description: |
+            Total LLM tokens (input + output) used today on this compute node.
+            Provided for display purposes — enforcement is dollar-based. Useful
+            for a less in-your-face usage caption ("28k tokens today") than
+            dollar amounts on every chat turn.
+        monthlyTokens:
+          type: integer
+          format: int64
+          description: |
+            Total LLM tokens (input + output) used this calendar month on this
+            compute node. Same display-only role as dailyTokens.
   responses:
     Unauthorized:
       description: Incorrect authentication or user has incorrect permissions.


### PR DESCRIPTION
## Summary

Frontend wants to display "28k tokens today" instead of "\$0.42 today" in the always-visible chat quota pill — tokens read like a usage stat, dollars read like a bill running on every chat turn.

The data is already tracked in the chat_user_usage row; this just exposes it on the /effective resolver response. Enforcement stays dollar-based; tokens are display-only.

## Schema additions

\`chatUserEffectiveQuota\`:
- \`dailyTokens\` (int64) — input + output tokens used today
- \`monthlyTokens\` (int64) — same for current calendar month

OpenAPI updated.

## Coordinated PR

Pennsieve/pennsieve-app — companion frontend change that consumes these fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)