### PR TITLE
compute: owner-only GET/PUT /compute-nodes/{id}/llm-config

### DIFF
--- a/internal/handler/compute/llm_config_handler.go
+++ b/internal/handler/compute/llm_config_handler.go
@@ -1,0 +1,100 @@
+package compute
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/pennsieve/account-service/internal/errors"
+)
+
+// llmConfigRequest is the body shape for PutLLMConfigHandler. Mirrors the
+// gateway's wire shape so the proxy is a straight pass-through. Period is
+// "daily" or "monthly".
+type llmConfigRequest struct {
+	BudgetUsd    float64 `json:"budgetUsd"`
+	BudgetPeriod string  `json:"budgetPeriod"`
+}
+
+// PutLLMConfigHandler is the owner-only PUT for the node-wide LLM cost
+// budget. Forwards to the compute-gateway, which writes the SSM parameter
+// the governor reads on every invocation (chat + workflow apps).
+func PutLLMConfigHandler(ctx context.Context, request events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	handlerName := "PutLLMConfigHandler"
+
+	sctx, errResp := initSecretsContext(ctx, request, handlerName, true)
+	if errResp != nil {
+		return *errResp, nil
+	}
+
+	var body llmConfigRequest
+	if err := json.Unmarshal([]byte(request.Body), &body); err != nil {
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: http.StatusBadRequest,
+			Body:       errors.ComputeHandlerError(handlerName, errors.ErrUnmarshaling),
+		}, nil
+	}
+	if body.BudgetUsd < 0 {
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: http.StatusBadRequest,
+			Body:       `{"message":"budgetUsd must be non-negative"}`,
+		}, nil
+	}
+	if body.BudgetPeriod != "daily" && body.BudgetPeriod != "monthly" {
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: http.StatusBadRequest,
+			Body:       `{"message":"budgetPeriod must be 'daily' or 'monthly'"}`,
+		}, nil
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		log.Printf("Error marshaling LLM config payload: %v", err)
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: http.StatusInternalServerError,
+			Body:       errors.ComputeHandlerError(handlerName, errors.ErrMarshaling),
+		}, nil
+	}
+
+	respBody, err := sctx.ProvisionerClient.Put(ctx, "/llm-config", payload)
+	if err != nil {
+		log.Printf("Error putting LLM config: %v", err)
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: http.StatusInternalServerError,
+			Body:       errors.ComputeHandlerError(handlerName, errors.ErrProvisionerRequest),
+		}, nil
+	}
+
+	return events.APIGatewayV2HTTPResponse{
+		StatusCode: http.StatusOK,
+		Body:       string(respBody),
+	}, nil
+}
+
+// GetLLMConfigHandler is owner-only. The current budget is policy data,
+// not user-scoped, so we don't expose it more widely. Shared/team users
+// who hit the cap see the rejection message from the governor itself.
+func GetLLMConfigHandler(ctx context.Context, request events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	handlerName := "GetLLMConfigHandler"
+
+	sctx, errResp := initSecretsContext(ctx, request, handlerName, true)
+	if errResp != nil {
+		return *errResp, nil
+	}
+
+	respBody, err := sctx.ProvisionerClient.Get(ctx, "/llm-config")
+	if err != nil {
+		log.Printf("Error getting LLM config: %v", err)
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: http.StatusInternalServerError,
+			Body:       errors.ComputeHandlerError(handlerName, errors.ErrProvisionerRequest),
+		}, nil
+	}
+
+	return events.APIGatewayV2HTTPResponse{
+		StatusCode: http.StatusOK,
+		Body:       string(respBody),
+	}, nil
+}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -70,6 +70,14 @@ func AccountServiceHandler(ctx context.Context, request events.APIGatewayV2HTTPR
     router.PUT("/compute-nodes/{id}/allowed-processors", computeHandler.PutAllowedProcessorsHandler)
     router.GET("/compute-nodes/{id}/allowed-processors", computeHandler.GetAllowedProcessorsHandler)
 
+    // Node-wide LLM cost budget (the SSM-backed cap the governor enforces).
+    // Owner-only. Distinct from the per-user chat quotas below: this cap
+    // applies to *every* LLM caller on the node — chat *and* workflow
+    // applications. It's the only backstop for application-initiated runs
+    // since those don't go through chat-service's CheckTurn.
+    router.PUT("/compute-nodes/{id}/llm-config", computeHandler.PutLLMConfigHandler)
+    router.GET("/compute-nodes/{id}/llm-config", computeHandler.GetLLMConfigHandler)
+
     // Per-user chat & workflow LLM quotas. Owner-only for PUT/DELETE/list and
     // for reads of the `__default__` row. GET of a specific user's row +
     // /effective + /user-usage allow the user themselves (or "me" alias).

--- a/terraform/accounts-service.yml
+++ b/terraform/accounts-service.yml
@@ -2136,6 +2136,117 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '5XX':
           $ref: '#/components/responses/Error'
+  /compute-nodes/{id}/llm-config:
+    put:
+      summary: Set node-wide LLM cost budget
+      description: |
+        Updates the node-wide LLM cost budget the governor enforces on every
+        invocation. Applies to chat and to workflow applications that invoke
+        the LLM — this is the only enforcement layer that catches non-chat
+        callers (per-user chat quotas don't apply to workflow apps).
+
+        **Permissions:** Node owner only.
+
+        Note: the governor caches SSM values for ~60 seconds, so changes take
+        up to a minute to take effect on in-flight invocations.
+      x-amazon-apigateway-integration:
+        $ref: '#/components/x-amazon-apigateway-integrations/account-service'
+      operationId: putLLMConfig
+      security:
+        - token_auth: [ ]
+      tags:
+        - Compute Nodes
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          description: The UUID of the compute node
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - budgetUsd
+                - budgetPeriod
+              properties:
+                budgetUsd:
+                  type: number
+                  format: double
+                  minimum: 0
+                  description: Cost cap in USD for the chosen period.
+                budgetPeriod:
+                  type: string
+                  enum: [daily, monthly]
+                  description: Period the cap applies to.
+      responses:
+        '200':
+          description: LLM budget updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  budgetUsd:
+                    type: number
+                    format: double
+                  budgetPeriod:
+                    type: string
+                    enum: [daily, monthly]
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '4XX':
+          $ref: '#/components/responses/Unauthorized'
+        '5XX':
+          $ref: '#/components/responses/Error'
+    get:
+      summary: Get node-wide LLM cost budget
+      description: |
+        Returns the current node-wide LLM cost budget. Owner-only — the cap
+        is policy data and isn't surfaced to non-owners.
+      x-amazon-apigateway-integration:
+        $ref: '#/components/x-amazon-apigateway-integrations/account-service'
+      operationId: getLLMConfig
+      security:
+        - token_auth: [ ]
+      tags:
+        - Compute Nodes
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          description: The UUID of the compute node
+      responses:
+        '200':
+          description: Current LLM budget
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  budgetUsd:
+                    type: number
+                    format: double
+                  budgetPeriod:
+                    type: string
+                    enum: [daily, monthly]
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '4XX':
+          $ref: '#/components/responses/Unauthorized'
+        '5XX':
+          $ref: '#/components/responses/Error'
   /compute-nodes/{id}/user-quotas:
     get:
       summary: List per-user chat & workflow LLM quotas for a compute node


### PR DESCRIPTION
## Summary

Adds the missing admin-facing surface for the **node-wide LLM cost budget** — the SSM-backed cap the governor enforces on every Bedrock invocation. Until now it could only be changed by re-running Terraform; this PR lets a node owner update it through the API (and through the new admin UI in pennsieve-app).

Two new endpoints, both owner-only:

- \`GET  /compute-nodes/{id}/llm-config\` — current budget
- \`PUT  /compute-nodes/{id}/llm-config\` — update budget (\`{budgetUsd, budgetPeriod}\`, period ∈ {daily, monthly})

Implementation follows the existing \`allowed-processors\` pattern: \`initSecretsContext\` for auth, \`ProvisionerClient.Get/Put\` to forward to the compute-gateway, gateway writes SSM.

## Why this matters

This is the **only enforcement layer that catches workflow applications** invoking the LLM. Per-user chat quotas (added in [#62](https://github.com/Pennsieve/account-service/pull/62)) only fire in chat-service's \`CheckTurn\`, so anything that bypasses chat-service — direct API workflow runs, scheduled jobs, apps invoking the governor from a processor — sees only the node-wide cap. Surfacing that cap to admins closes the loop.

## Companion changes

- **compute-node-aws-provisioner-v2** — gateway \`handleLLMConfig\` handler + \`BUDGET_SSM_PARAM\` env var on the gateway Lambda. IAM perms to \`PutParameter\` were already granted in \`llm-governor.tf\`. ([branch \`feat/per-user-llm-quotas\`](https://github.com/Pennsieve/compute-node-aws-provisioner-v2/tree/feat/per-user-llm-quotas))
- **pennsieve-app** — new "Node LLM Budget" section on the compute-node management page, rendered above the renamed "Per-user LLM Quotas" section. ([PR #708](https://github.com/Pennsieve/pennsieve-app/pull/708))

## Notes

- Owner-only on both verbs — the cap is policy data, not user-scoped.
- The governor caches SSM values for ~60 seconds, so writes through this endpoint take up to a minute to take effect on in-flight invocations. UI surfaces this in the section copy.
- OpenAPI spec updated with both endpoints.

## Test plan

- [ ] \`PUT /compute-nodes/{id}/llm-config\` as the node owner with \`{budgetUsd: 25, budgetPeriod: "daily"}\` → 200, SSM parameter updated.
- [ ] \`GET\` returns the same shape.
- [ ] Non-owner \`PUT\` → 403.
- [ ] \`PUT\` with negative \`budgetUsd\` → 400.
- [ ] \`PUT\` with \`budgetPeriod: "weekly"\` → 400.
- [ ] \`GET\` on a node with LLM disabled → 503 from gateway, surfaced as 500 from account-service (acceptable — UI hides the section in that state anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)