### PR TITLE
compute: audit log mutations on LLM budget + per-user quota endpoints

### DIFF
--- a/internal/handler/compute/chat_quota_handlers.go
+++ b/internal/handler/compute/chat_quota_handlers.go
@@ -3,6 +3,7 @@ package compute
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -225,17 +226,39 @@ func PutChatUserQuotaHandler(ctx context.Context, request events.APIGatewayV2HTT
 	quotaStore := store_dynamodb.NewChatUserQuotaStore(qctx.DDB, qctx.QuotaTbl)
 	if err := quotaStore.Put(ctx, quota); err != nil {
 		log.Printf("Error putting chat user quota: %v", err)
+		log.Printf("AUDIT action=put_chat_user_quota result=failure caller=%q node=%q target=%q error=%q",
+			qctx.UserID, qctx.NodeUuid, qctx.TargetUid, err.Error())
 		return events.APIGatewayV2HTTPResponse{
 			StatusCode: http.StatusInternalServerError,
 			Body:       errors.ComputeHandlerError(handlerName, errors.ErrDynamoDB),
 		}, nil
 	}
 
+	// Audit trail of admin actions on per-user cost caps. See
+	// llm_config_handler.go for the HIPAA / NIST rationale. We log
+	// the three cap axes as pointers-or-nil so the entry distinguishes
+	// "explicitly set to 0" from "cleared / falls back to default".
+	log.Printf("AUDIT action=put_chat_user_quota result=success caller=%q node=%q target=%q daily=%s monthly=%s perWorkflow=%s",
+		qctx.UserID, qctx.NodeUuid, qctx.TargetUid,
+		formatNullableUsd(quota.DailyCostUsd),
+		formatNullableUsd(quota.MonthlyCostUsd),
+		formatNullableUsd(quota.PerWorkflowUsd))
+
 	out, _ := json.Marshal(quota)
 	return events.APIGatewayV2HTTPResponse{
 		StatusCode: http.StatusOK,
 		Body:       string(out),
 	}, nil
+}
+
+// formatNullableUsd renders an optional cap value for audit log lines.
+// `null` means the axis is unset on this row (falls through to the next
+// resolution tier); a number means an explicit cap (including $0.00).
+func formatNullableUsd(v *float64) string {
+	if v == nil {
+		return "null"
+	}
+	return fmt.Sprintf("%.2f", *v)
 }
 
 // GetChatUserQuotaHandler returns the quota row for (nodeId, userId), or 404 if none.
@@ -330,11 +353,16 @@ func DeleteChatUserQuotaHandler(ctx context.Context, request events.APIGatewayV2
 	quotaStore := store_dynamodb.NewChatUserQuotaStore(qctx.DDB, qctx.QuotaTbl)
 	if err := quotaStore.Delete(ctx, qctx.NodeUuid, qctx.TargetUid); err != nil {
 		log.Printf("Error deleting chat user quota: %v", err)
+		log.Printf("AUDIT action=delete_chat_user_quota result=failure caller=%q node=%q target=%q error=%q",
+			qctx.UserID, qctx.NodeUuid, qctx.TargetUid, err.Error())
 		return events.APIGatewayV2HTTPResponse{
 			StatusCode: http.StatusInternalServerError,
 			Body:       errors.ComputeHandlerError(handlerName, errors.ErrDynamoDB),
 		}, nil
 	}
+
+	log.Printf("AUDIT action=delete_chat_user_quota result=success caller=%q node=%q target=%q",
+		qctx.UserID, qctx.NodeUuid, qctx.TargetUid)
 
 	return events.APIGatewayV2HTTPResponse{
 		StatusCode: http.StatusOK,

--- a/internal/handler/compute/llm_config_handler.go
+++ b/internal/handler/compute/llm_config_handler.go
@@ -61,11 +61,23 @@ func PutLLMConfigHandler(ctx context.Context, request events.APIGatewayV2HTTPReq
 	respBody, err := sctx.ProvisionerClient.Put(ctx, "/llm-config", payload)
 	if err != nil {
 		log.Printf("Error putting LLM config: %v", err)
+		// Audit the attempt even on failure — HIPAA §164.312(b) wants
+		// unsuccessful access attempts logged as well.
+		log.Printf("AUDIT action=put_llm_budget result=failure caller=%q node=%q budgetUsd=%.2f period=%q error=%q",
+			sctx.UserID, sctx.NodeUuid, body.BudgetUsd, body.BudgetPeriod, err.Error())
 		return events.APIGatewayV2HTTPResponse{
 			StatusCode: http.StatusInternalServerError,
 			Body:       errors.ComputeHandlerError(handlerName, errors.ErrProvisionerRequest),
 		}, nil
 	}
+
+	// Audit trail of admin actions on cost-governance config. HIPAA
+	// §164.312(b) / NIST 800-171 AU-2: changes to security-relevant config
+	// on PHI-processing systems must be logged with caller identity. The
+	// budget value itself isn't PHI; we log it so audit can show the
+	// before/after delta.
+	log.Printf("AUDIT action=put_llm_budget result=success caller=%q node=%q budgetUsd=%.2f period=%q",
+		sctx.UserID, sctx.NodeUuid, body.BudgetUsd, body.BudgetPeriod)
 
 	return events.APIGatewayV2HTTPResponse{
 		StatusCode: http.StatusOK,


### PR DESCRIPTION
## Summary

Adds structured \`AUDIT\` log lines on every mutation of the LLM cost
governance config (node-wide budget + per-user caps). Closes a HIPAA
§164.312(b) / NIST 800-171 AU-2 gap surfaced during a security review of
the work in [#64](https://github.com/Pennsieve/account-service/pull/64).

Three handlers gain audit logging:

- \`PutLLMConfigHandler\` — node-wide budget mutation
- \`PutChatUserQuotaHandler\` — per-user cap mutation
- \`DeleteChatUserQuotaHandler\` — per-user cap removal

Each entry includes \`action=\`, \`result=\` (success / failure), \`caller=\`
(JWT-authenticated userId), \`node=\`, \`target=\` (for per-user changes),
and the new values. Failed attempts are audited too — the rule covers
unsuccessful access attempts.

Per-axis caps are emitted as either \`%.2f\` or \`null\` so the entry
distinguishes \"explicit \$0 cap\" from \"cleared, falls back to default\".

## Why this is needed

The DynamoDB-level \`UpdatedBy\` field on each quota row already captures
*last-mutator* at-rest, but there's no time-series view of *who changed
what when* across the table. CloudWatch Logs is the obvious place for
that audit trail, and 800-171 AU-12 expects it to be query-able. The
\`AUDIT\` prefix is stable + greppable in Insights queries.

## Why no gateway-side logging

The gateway only ever sees the account-service Lambda role as the caller
(SigV4-signed cross-account invoke). The end-user identity is knowable
only upstream and is logged there. Gateway-side logging would just
record \"account-service\" on every line.

## Test plan

- [ ] Update a node budget through the UI → CloudWatch shows one
  \`AUDIT action=put_llm_budget result=success caller=…\` entry.
- [ ] Set a per-user cap → one \`AUDIT action=put_chat_user_quota …\`
  entry with \`caller=\` ≠ \`target=\`.
- [ ] Delete a per-user cap → one \`AUDIT action=delete_chat_user_quota …\`
  entry.
- [ ] Force a DynamoDB failure (e.g. invalid table name) → \`AUDIT … result=failure error=\"…\"\` entry alongside the existing \`Error …\` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)