### PR TITLE
account-service: maxInteractiveSessions in update-config (enable interactive on existing nodes)

### DIFF
--- a/internal/handler/compute/eventbridge_handler.go
+++ b/internal/handler/compute/eventbridge_handler.go
@@ -8,9 +8,11 @@ import (
 	"os"
 
 	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	"github.com/pennsieve/account-service/internal/interactivedns"
+	"github.com/pennsieve/account-service/internal/models"
 	"github.com/pennsieve/account-service/internal/store_dynamodb"
 	"github.com/pennsieve/account-service/internal/utils"
 )
@@ -123,17 +125,22 @@ func handleProvisioningComplete(ctx context.Context, nodeStore store_dynamodb.No
 
 	log.Printf("Successfully updated node %s to Enabled status with infrastructure details", event.ComputeNodeId)
 
-	// Best-effort: refresh the interactive subdomain NS delegation if present.
-	ensureInteractiveDelegation(ctx, event)
+	// Best-effort: create/refresh the interactive subdomain NS delegation, and —
+	// if this is the FIRST time the zone is delegated — kick off phase 2 (cert
+	// validation + HTTPS listener), which the provisioner deliberately skipped on
+	// the first pass to avoid deadlocking on an undelegated zone.
+	ensureInteractiveDelegation(ctx, nodeStore, event)
 	return nil
 }
 
 // ensureInteractiveDelegation upserts the NS delegation for the node's
-// interactive-session subdomain in the Pennsieve parent zone. Best-effort: a
-// failure here must not fail provisioning (the node is already Enabled). The
-// delegation logic lives in interactivedns and is transport-agnostic so a
-// future non-AWS (e.g. Azure) provisioner can reuse it via a different channel.
-func ensureInteractiveDelegation(ctx context.Context, event ComputeNodeEvent) {
+// interactive-session subdomain in the Pennsieve parent zone, then — only when
+// the delegation was NEWLY created — auto-triggers a phase-2 re-provision so the
+// HTTPS listener comes up without any operator action. Best-effort: a failure
+// here must not fail provisioning (the node is already Enabled). The delegation
+// logic lives in interactivedns and is transport-agnostic so a future non-AWS
+// (e.g. Azure) provisioner can reuse it via a different channel.
+func ensureInteractiveDelegation(ctx context.Context, nodeStore store_dynamodb.NodeStore, event ComputeNodeEvent) {
 	if event.InteractiveZoneName == "" || len(event.InteractiveZoneNameServers) == 0 {
 		return
 	}
@@ -148,11 +155,19 @@ func ensureInteractiveDelegation(ctx context.Context, event ComputeNodeEvent) {
 		return
 	}
 	r53 := route53.NewFromConfig(cfg)
-	if err := interactivedns.EnsureZoneDelegation(ctx, r53, parentZoneID, event.InteractiveZoneName, event.InteractiveZoneNameServers); err != nil {
+	created, err := interactivedns.EnsureZoneDelegation(ctx, r53, parentZoneID, event.InteractiveZoneName, event.InteractiveZoneNameServers)
+	if err != nil {
 		log.Printf("Warning: failed to ensure NS delegation for %s: %v", event.InteractiveZoneName, err)
 		return
 	}
-	log.Printf("Ensured interactive NS delegation for %s (%d name servers)", event.InteractiveZoneName, len(event.InteractiveZoneNameServers))
+	log.Printf("Ensured interactive NS delegation for %s (%d name servers, newlyCreated=%v)", event.InteractiveZoneName, len(event.InteractiveZoneNameServers), created)
+
+	// Loop-safe: only on first delegation. Phase 2 is itself an UPDATE → its
+	// event re-runs this, but by then the NS record exists → created=false → no
+	// re-trigger.
+	if created {
+		triggerInteractivePhase2(ctx, cfg, nodeStore, event.ComputeNodeId)
+	}
 }
 
 func handleProvisioningError(ctx context.Context, nodeStore store_dynamodb.NodeStore, detail json.RawMessage) error {
@@ -236,7 +251,7 @@ func handleUpdateComplete(ctx context.Context, nodeStore store_dynamodb.NodeStor
 	// Best-effort: refresh the interactive subdomain NS delegation if present.
 	// An UPDATE that just enabled interactive (or re-created the shared zone)
 	// carries fresh name servers, so re-upserting keeps the delegation current.
-	ensureInteractiveDelegation(ctx, event)
+	ensureInteractiveDelegation(ctx, nodeStore, event)
 	return nil
 }
 
@@ -257,6 +272,10 @@ func handleDeleteComplete(ctx context.Context, nodeStore store_dynamodb.NodeStor
 	}
 
 	dynamoDBClient := dynamodb.NewFromConfig(cfg)
+
+	// Capture the node's account before we delete it, so we can decide whether
+	// the per-account interactive DNS delegation should be torn down.
+	deletedNode, _ := nodeStore.GetById(ctx, event.ComputeNodeId)
 
 	// Clean up all node access records (permissions) for this node
 	nodeAccessTable := os.Getenv("NODE_ACCESS_TABLE")
@@ -279,5 +298,40 @@ func handleDeleteComplete(ctx context.Context, nodeStore store_dynamodb.NodeStor
 	}
 
 	log.Printf("Successfully deleted node %s and all associated access records from database", event.ComputeNodeId)
+
+	// If this account no longer has any interactive node, the per-account
+	// interactive zone is (being) torn down — remove its NS delegation from the
+	// Pennsieve parent zone so it doesn't dangle. Best-effort.
+	removeInteractiveDelegationIfUnused(ctx, cfg, nodeStore, deletedNode)
 	return nil
+}
+
+// removeInteractiveDelegationIfUnused deletes the parent-zone NS delegation for
+// the account's interactive subdomain when no interactive nodes remain for the
+// account (i.e. the per-account zone is gone or about to be). Safe: if a node
+// later re-enables interactive, the provisioner re-creates the zone and
+// account-service re-delegates. No-op if interactive was never in play.
+func removeInteractiveDelegationIfUnused(ctx context.Context, cfg aws.Config, nodeStore store_dynamodb.NodeStore, deletedNode models.DynamoDBNode) {
+	parentZoneID := os.Getenv("INTERACTIVE_PARENT_ZONE_ID")
+	parentDomain := os.Getenv("INTERACTIVE_PARENT_DOMAIN")
+	if parentZoneID == "" || parentDomain == "" || deletedNode.AccountUuid == "" || deletedNode.AccountId == "" {
+		return
+	}
+	remaining, err := nodeStore.GetByAccount(ctx, deletedNode.AccountUuid)
+	if err != nil {
+		log.Printf("Warning: could not list account %s nodes for delegation cleanup: %v", deletedNode.AccountUuid, err)
+		return
+	}
+	for _, n := range remaining {
+		if n.MaxInteractiveSessions > 0 {
+			return // another interactive node still needs the zone
+		}
+	}
+	zoneName := fmt.Sprintf("%s.%s", deletedNode.AccountId, parentDomain)
+	r53 := route53.NewFromConfig(cfg)
+	if err := interactivedns.RemoveZoneDelegation(ctx, r53, parentZoneID, zoneName); err != nil {
+		log.Printf("Warning: failed to remove NS delegation for %s: %v", zoneName, err)
+		return
+	}
+	log.Printf("Removed interactive NS delegation for %s (no interactive nodes remain)", zoneName)
 }

--- a/internal/handler/compute/post_update_config_handler.go
+++ b/internal/handler/compute/post_update_config_handler.go
@@ -24,9 +24,10 @@ import (
 // UpdateConfigRequest is the request body for POST /compute-nodes/{id}/update-config.
 // Only infrastructure-affecting fields are accepted. Nil fields are left unchanged.
 type UpdateConfigRequest struct {
-	MaxGpuInstances *int    `json:"maxGpuInstances,omitempty"`
-	GpuTier         *string `json:"gpuTier,omitempty"`
-	EnableLLMAccess *bool   `json:"enableLLMAccess,omitempty"`
+	MaxGpuInstances        *int    `json:"maxGpuInstances,omitempty"`
+	GpuTier                *string `json:"gpuTier,omitempty"`
+	EnableLLMAccess        *bool   `json:"enableLLMAccess,omitempty"`
+	MaxInteractiveSessions *int    `json:"maxInteractiveSessions,omitempty"`
 }
 
 // PostUpdateConfigHandler updates infrastructure configuration for a compute node
@@ -59,7 +60,7 @@ func PostUpdateConfigHandler(ctx context.Context, request events.APIGatewayV2HTT
 	}
 
 	// Must provide at least one field
-	if req.MaxGpuInstances == nil && req.GpuTier == nil && req.EnableLLMAccess == nil {
+	if req.MaxGpuInstances == nil && req.GpuTier == nil && req.EnableLLMAccess == nil && req.MaxInteractiveSessions == nil {
 		return events.APIGatewayV2HTTPResponse{
 			StatusCode: http.StatusBadRequest,
 			Body:       errors.ComputeHandlerError(handlerName, errors.ErrUnmarshaling),
@@ -68,6 +69,12 @@ func PostUpdateConfigHandler(ctx context.Context, request events.APIGatewayV2HTT
 
 	// Validate values
 	if req.MaxGpuInstances != nil && *req.MaxGpuInstances < 0 {
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: http.StatusBadRequest,
+			Body:       errors.ComputeHandlerError(handlerName, errors.ErrBadRequest),
+		}, nil
+	}
+	if req.MaxInteractiveSessions != nil && *req.MaxInteractiveSessions < 0 {
 		return events.APIGatewayV2HTTPResponse{
 			StatusCode: http.StatusBadRequest,
 			Body:       errors.ComputeHandlerError(handlerName, errors.ErrBadRequest),
@@ -156,6 +163,9 @@ func PostUpdateConfigHandler(ctx context.Context, request events.APIGatewayV2HTT
 	if req.EnableLLMAccess != nil {
 		computeNode.EnableLLMAccess = *req.EnableLLMAccess
 	}
+	if req.MaxInteractiveSessions != nil {
+		computeNode.MaxInteractiveSessions = *req.MaxInteractiveSessions
+	}
 
 	// Save to DynamoDB
 	if err := nodesStore.Put(ctx, computeNode); err != nil {
@@ -165,8 +175,8 @@ func PostUpdateConfigHandler(ctx context.Context, request events.APIGatewayV2HTT
 			Body:       errors.ComputeHandlerError(handlerName, errors.ErrDynamoDB),
 		}, nil
 	}
-	log.Printf("Updated config for node %s: maxGpuInstances=%d, gpuTier=%s, enableLLMAccess=%v",
-		nodeUuid, computeNode.MaxGpuInstances, computeNode.GpuTier, computeNode.EnableLLMAccess)
+	log.Printf("Updated config for node %s: maxGpuInstances=%d, gpuTier=%s, enableLLMAccess=%v, maxInteractiveSessions=%d",
+		nodeUuid, computeNode.MaxGpuInstances, computeNode.GpuTier, computeNode.EnableLLMAccess, computeNode.MaxInteractiveSessions)
 
 	// Trigger re-provisioning
 	envValue := os.Getenv("ENV")
@@ -219,29 +229,35 @@ func PostUpdateConfigHandler(ctx context.Context, request events.APIGatewayV2HTT
 	if computeNode.EnableLLMAccess {
 		enableLLMAccess = "true"
 	}
+	enableInteractive := "false"
+	if computeNode.MaxInteractiveSessions > 0 {
+		enableInteractive = "true"
+	}
 
 	env := buildEnvVars(map[string]string{
-		"COMPUTE_NODE_ID":     nodeUuid,
-		"ENV":                 envValue,
-		"ACTION":              "UPDATE",
-		"COMPUTE_NODES_TABLE": computeNodesTable,
-		"ORG_ID":              computeNode.OrganizationId,
-		"USER_ID":             userId,
-		"ACCOUNT_ID":          computeNode.AccountId,
-		"UUID":                computeNode.AccountUuid,
-		"ACCOUNT_TYPE":        computeNode.AccountType,
-		"WM_TAG":              computeNode.WorkflowManagerTag,
-		"WM_CPU":              "2048",
-		"WM_MEMORY":           "4096",
-		"NODE_IDENTIFIER":     nodeIdentifier,
-		"NODE_NAME":           computeNode.Name,
-		"PROVISIONER_IMAGE":     provisionerImage,
-		"PROVISIONER_IMAGE_TAG": provisionerImageTag,
-		"DEPLOYMENT_MODE":     deploymentMode,
-		"ENABLE_LLM_ACCESS":   enableLLMAccess,
-		"MAX_GPU_INSTANCES":   strconv.Itoa(computeNode.MaxGpuInstances),
-		"GPU_TIER":            computeNode.GpuTier,
-		"ROLE_NAME":           account.RoleName,
+		"COMPUTE_NODE_ID":          nodeUuid,
+		"ENV":                      envValue,
+		"ACTION":                   "UPDATE",
+		"COMPUTE_NODES_TABLE":      computeNodesTable,
+		"ORG_ID":                   computeNode.OrganizationId,
+		"USER_ID":                  userId,
+		"ACCOUNT_ID":               computeNode.AccountId,
+		"UUID":                     computeNode.AccountUuid,
+		"ACCOUNT_TYPE":             computeNode.AccountType,
+		"WM_TAG":                   computeNode.WorkflowManagerTag,
+		"WM_CPU":                   "2048",
+		"WM_MEMORY":                "4096",
+		"NODE_IDENTIFIER":          nodeIdentifier,
+		"NODE_NAME":                computeNode.Name,
+		"PROVISIONER_IMAGE":        provisionerImage,
+		"PROVISIONER_IMAGE_TAG":    provisionerImageTag,
+		"DEPLOYMENT_MODE":          deploymentMode,
+		"ENABLE_LLM_ACCESS":        enableLLMAccess,
+		"MAX_GPU_INSTANCES":        strconv.Itoa(computeNode.MaxGpuInstances),
+		"GPU_TIER":                 computeNode.GpuTier,
+		"MAX_INTERACTIVE_SESSIONS": strconv.Itoa(computeNode.MaxInteractiveSessions),
+		"ENABLE_INTERACTIVE":       enableInteractive,
+		"ROLE_NAME":                account.RoleName,
 	})
 
 	runTaskIn := &ecs.RunTaskInput{

--- a/internal/handler/compute/reprovision_phase2.go
+++ b/internal/handler/compute/reprovision_phase2.go
@@ -1,0 +1,137 @@
+package compute
+
+import (
+	"context"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/pennsieve/account-service/internal/runner"
+	"github.com/pennsieve/account-service/internal/store_dynamodb"
+)
+
+// triggerInteractivePhase2 launches an UPDATE re-provision of the node so the
+// provisioner can complete interactive phase 2 (ACM cert validation + the shared
+// ALB's HTTPS listener) now that the per-account zone has just been delegated.
+//
+// Phase 1 (the original create/update) deliberately skipped validation/listener
+// to avoid the apply deadlocking on an undelegated zone. This is the auto-trigger
+// that makes "create a node in the app" fully deploy interactive with no operator
+// action — it's invoked only when the NS delegation was newly created, so it
+// can't loop (phase 2 is itself an UPDATE whose event finds the delegation
+// already present). Best-effort: a failure just means the operator (or the next
+// node update) completes phase 2 on a later pass.
+func triggerInteractivePhase2(ctx context.Context, cfg aws.Config, nodeStore store_dynamodb.NodeStore, computeNodeID string) {
+	envValue := os.Getenv("ENV")
+	if envValue == "DOCKER" || envValue == "TEST" {
+		return
+	}
+
+	node, err := nodeStore.GetById(ctx, computeNodeID)
+	if err != nil || node.Uuid == "" {
+		log.Printf("phase2: could not load node %s: %v", computeNodeID, err)
+		return
+	}
+	if node.MaxInteractiveSessions <= 0 {
+		return // interactive not (or no longer) enabled
+	}
+
+	cluster := os.Getenv("CLUSTER_ARN")
+	taskDefContainerName := os.Getenv("TASK_DEF_CONTAINER_NAME")
+	securityGroup := os.Getenv("SECURITY_GROUP")
+	if cluster == "" || taskDefContainerName == "" || securityGroup == "" || os.Getenv("SUBNET_IDS") == "" {
+		log.Printf("phase2: launch env not configured on this lambda (CLUSTER_ARN/SUBNET_IDS/SECURITY_GROUP/TASK_DEF_CONTAINER_NAME); skipping auto-trigger for node %s", computeNodeID)
+		return
+	}
+	subnetIDs := strings.Split(os.Getenv("SUBNET_IDS"), ",")
+
+	// Resolve the per-account compute role for the provisioner to assume.
+	account, err := store_dynamodb.NewAccountDatabaseStore(dynamodb.NewFromConfig(cfg), os.Getenv("ACCOUNTS_TABLE")).GetById(ctx, node.AccountUuid)
+	if err != nil {
+		log.Printf("phase2: could not load account %s: %v", node.AccountUuid, err)
+		return
+	}
+
+	provisionerImage := node.ProvisionerImage
+	if provisionerImage == "" {
+		provisionerImage = "pennsieve/compute-node-aws-provisioner-v2"
+	}
+	provisionerImageTag := node.ProvisionerImageTag
+	if provisionerImageTag == "" {
+		provisionerImageTag = "latest"
+	}
+
+	client := ecs.NewFromConfig(cfg)
+	taskDef, err := createDynamicTaskDefinition(ctx, client, provisionerImage, provisionerImageTag, envValue)
+	if err != nil {
+		log.Printf("phase2: task def for node %s: %v", computeNodeID, err)
+		return
+	}
+
+	nodeIdentifier := node.Identifier
+	if nodeIdentifier == "" {
+		nodeIdentifier = node.Uuid[:8]
+	}
+	deploymentMode := node.DeploymentMode
+	if deploymentMode == "" {
+		deploymentMode = "basic"
+	}
+	enableLLM := "false"
+	if node.EnableLLMAccess {
+		enableLLM = "true"
+	}
+
+	env := buildEnvVars(map[string]string{
+		"COMPUTE_NODE_ID":          node.Uuid,
+		"ENV":                      envValue,
+		"ACTION":                   "UPDATE",
+		"COMPUTE_NODES_TABLE":      os.Getenv("COMPUTE_NODES_TABLE"),
+		"ORG_ID":                   node.OrganizationId,
+		"USER_ID":                  node.UserId,
+		"ACCOUNT_ID":               node.AccountId,
+		"UUID":                     node.AccountUuid,
+		"ACCOUNT_TYPE":             node.AccountType,
+		"WM_TAG":                   node.WorkflowManagerTag,
+		"WM_CPU":                   "2048",
+		"WM_MEMORY":                "4096",
+		"NODE_IDENTIFIER":          nodeIdentifier,
+		"NODE_NAME":                node.Name,
+		"PROVISIONER_IMAGE":        provisionerImage,
+		"PROVISIONER_IMAGE_TAG":    provisionerImageTag,
+		"DEPLOYMENT_MODE":          deploymentMode,
+		"ENABLE_LLM_ACCESS":        enableLLM,
+		"MAX_GPU_INSTANCES":        strconv.Itoa(node.MaxGpuInstances),
+		"GPU_TIER":                 node.GpuTier,
+		"MAX_INTERACTIVE_SESSIONS": strconv.Itoa(node.MaxInteractiveSessions),
+		"ENABLE_INTERACTIVE":       "true",
+		"ROLE_NAME":                account.RoleName,
+	})
+
+	runTaskIn := &ecs.RunTaskInput{
+		TaskDefinition: taskDef.TaskDefinitionArn,
+		Cluster:        aws.String(cluster),
+		NetworkConfiguration: &types.NetworkConfiguration{
+			AwsvpcConfiguration: &types.AwsVpcConfiguration{
+				Subnets:        subnetIDs,
+				SecurityGroups: []string{securityGroup},
+				AssignPublicIp: types.AssignPublicIpEnabled,
+			},
+		},
+		Overrides: &types.TaskOverride{
+			ContainerOverrides: []types.ContainerOverride{
+				{Name: &taskDefContainerName, Environment: env},
+			},
+		},
+		LaunchType: types.LaunchTypeFargate,
+	}
+	if err := runner.NewECSTaskRunner(client, runTaskIn).Run(ctx); err != nil {
+		log.Printf("phase2: re-provision RunTask for node %s failed: %v", computeNodeID, err)
+		return
+	}
+	log.Printf("phase2: auto-triggered re-provision (UPDATE) for node %s to complete interactive HTTPS", computeNodeID)
+}

--- a/internal/interactivedns/delegation.go
+++ b/internal/interactivedns/delegation.go
@@ -18,6 +18,7 @@ package interactivedns
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
@@ -28,17 +29,22 @@ import (
 // for testability).
 type Route53API interface {
 	ChangeResourceRecordSets(ctx context.Context, params *route53.ChangeResourceRecordSetsInput, optFns ...func(*route53.Options)) (*route53.ChangeResourceRecordSetsOutput, error)
+	ListResourceRecordSets(ctx context.Context, params *route53.ListResourceRecordSetsInput, optFns ...func(*route53.Options)) (*route53.ListResourceRecordSetsOutput, error)
 }
 
 // EnsureZoneDelegation upserts an NS record for zoneName in the Pennsieve parent
 // hosted zone (parentZoneID), pointing at nameServers. Idempotent: an UPSERT
 // refreshes the record if the node's zone was recreated with new name servers.
 //
-// It is a no-op (nil) when zoneName, nameServers, or parentZoneID is empty so
-// callers can invoke it unconditionally for any provisioning event.
-func EnsureZoneDelegation(ctx context.Context, r53 Route53API, parentZoneID, zoneName string, nameServers []string) error {
+// Returns created=true only when the NS record did not previously exist — the
+// caller uses this as a loop guard (e.g. trigger phase-2 re-provisioning only on
+// the first delegation, not on the UPDATE event that phase 2 itself emits).
+//
+// It is a no-op (created=false, nil) when zoneName, nameServers, or parentZoneID
+// is empty, so callers can invoke it unconditionally for any provisioning event.
+func EnsureZoneDelegation(ctx context.Context, r53 Route53API, parentZoneID, zoneName string, nameServers []string) (created bool, err error) {
 	if parentZoneID == "" || zoneName == "" || len(nameServers) == 0 {
-		return nil
+		return false, nil
 	}
 
 	records := make([]types.ResourceRecord, 0, len(nameServers))
@@ -49,10 +55,15 @@ func EnsureZoneDelegation(ctx context.Context, r53 Route53API, parentZoneID, zon
 		records = append(records, types.ResourceRecord{Value: aws.String(ns)})
 	}
 	if len(records) == 0 {
-		return nil
+		return false, nil
 	}
 
-	_, err := r53.ChangeResourceRecordSets(ctx, &route53.ChangeResourceRecordSetsInput{
+	existed, err := nsRecordExists(ctx, r53, parentZoneID, zoneName)
+	if err != nil {
+		return false, err
+	}
+
+	_, err = r53.ChangeResourceRecordSets(ctx, &route53.ChangeResourceRecordSetsInput{
 		HostedZoneId: aws.String(parentZoneID),
 		ChangeBatch: &types.ChangeBatch{
 			Comment: aws.String("interactive-session subdomain delegation (managed by account-service)"),
@@ -70,7 +81,66 @@ func EnsureZoneDelegation(ctx context.Context, r53 Route53API, parentZoneID, zon
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("upserting NS delegation for %s in parent zone %s: %w", zoneName, parentZoneID, err)
+		return false, fmt.Errorf("upserting NS delegation for %s in parent zone %s: %w", zoneName, parentZoneID, err)
+	}
+	return !existed, nil
+}
+
+// RemoveZoneDelegation deletes the NS delegation record for zoneName from the
+// parent zone. Used on node teardown once the per-account zone is destroyed, so
+// the parent zone doesn't keep a dangling delegation. No-op when the record
+// isn't there (idempotent) or when args are empty.
+func RemoveZoneDelegation(ctx context.Context, r53 Route53API, parentZoneID, zoneName string) error {
+	if parentZoneID == "" || zoneName == "" {
+		return nil
+	}
+	existing, err := getNSRecord(ctx, r53, parentZoneID, zoneName)
+	if err != nil {
+		return err
+	}
+	if existing == nil {
+		return nil // nothing to remove
+	}
+	_, err = r53.ChangeResourceRecordSets(ctx, &route53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(parentZoneID),
+		ChangeBatch: &types.ChangeBatch{
+			Comment: aws.String("interactive-session subdomain delegation removed (node torn down)"),
+			Changes: []types.Change{{
+				Action:            types.ChangeActionDelete,
+				ResourceRecordSet: existing, // must match the live record exactly
+			}},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("deleting NS delegation for %s in parent zone %s: %w", zoneName, parentZoneID, err)
 	}
 	return nil
+}
+
+// getNSRecord returns the live NS record set for name in the zone, or nil if absent.
+func getNSRecord(ctx context.Context, r53 Route53API, parentZoneID, name string) (*types.ResourceRecordSet, error) {
+	fqdn := name
+	if !strings.HasSuffix(fqdn, ".") {
+		fqdn += "."
+	}
+	out, err := r53.ListResourceRecordSets(ctx, &route53.ListResourceRecordSetsInput{
+		HostedZoneId:    aws.String(parentZoneID),
+		StartRecordName: aws.String(name),
+		StartRecordType: types.RRTypeNs,
+		MaxItems:        aws.Int32(1),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing NS record for %s: %w", name, err)
+	}
+	for i, rr := range out.ResourceRecordSets {
+		if rr.Type == types.RRTypeNs && aws.ToString(rr.Name) == fqdn {
+			return &out.ResourceRecordSets[i], nil
+		}
+	}
+	return nil, nil
+}
+
+func nsRecordExists(ctx context.Context, r53 Route53API, parentZoneID, name string) (bool, error) {
+	rr, err := getNSRecord(ctx, r53, parentZoneID, name)
+	return rr != nil, err
 }

--- a/internal/interactivedns/delegation_test.go
+++ b/internal/interactivedns/delegation_test.go
@@ -5,20 +5,30 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	"github.com/aws/aws-sdk-go-v2/service/route53/types"
 )
 
 type fakeRoute53 struct {
-	called bool
-	input  *route53.ChangeResourceRecordSetsInput
-	err    error
+	called   bool
+	input    *route53.ChangeResourceRecordSetsInput
+	err      error
+	existing []types.ResourceRecordSet // returned by ListResourceRecordSets
 }
 
 func (f *fakeRoute53) ChangeResourceRecordSets(ctx context.Context, params *route53.ChangeResourceRecordSetsInput, optFns ...func(*route53.Options)) (*route53.ChangeResourceRecordSetsOutput, error) {
 	f.called = true
 	f.input = params
 	return &route53.ChangeResourceRecordSetsOutput{}, f.err
+}
+
+func (f *fakeRoute53) ListResourceRecordSets(ctx context.Context, params *route53.ListResourceRecordSetsInput, optFns ...func(*route53.Options)) (*route53.ListResourceRecordSetsOutput, error) {
+	return &route53.ListResourceRecordSetsOutput{ResourceRecordSets: f.existing}, nil
+}
+
+func nsRRS(name string) types.ResourceRecordSet {
+	return types.ResourceRecordSet{Name: aws.String(name), Type: types.RRTypeNs}
 }
 
 func TestEnsureZoneDelegation_NoOpOnEmptyInputs(t *testing.T) {
@@ -36,49 +46,84 @@ func TestEnsureZoneDelegation_NoOpOnEmptyInputs(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			f := &fakeRoute53{}
-			if err := EnsureZoneDelegation(context.Background(), f, tc.parentZone, tc.zoneName, tc.nameServers); err != nil {
+			created, err := EnsureZoneDelegation(context.Background(), f, tc.parentZone, tc.zoneName, tc.nameServers)
+			if err != nil {
 				t.Fatalf("expected nil error, got %v", err)
 			}
-			if f.called {
-				t.Errorf("expected no Route53 call for %q", tc.name)
+			if created || f.called {
+				t.Errorf("expected no-op for %q (created=%v called=%v)", tc.name, created, f.called)
 			}
 		})
 	}
 }
 
-func TestEnsureZoneDelegation_UpsertsNSRecord(t *testing.T) {
-	f := &fakeRoute53{}
+func TestEnsureZoneDelegation_CreatesWhenAbsent(t *testing.T) {
+	f := &fakeRoute53{} // no existing records
 	ns := []string{"ns-1.awsdns-00.com", "ns-2.awsdns-00.net"}
-	err := EnsureZoneDelegation(context.Background(), f, "ZPARENT", "acct.compute.pennsieve.net", ns)
+	created, err := EnsureZoneDelegation(context.Background(), f, "ZPARENT", "acct.compute.pennsieve.net", ns)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !f.called {
-		t.Fatal("expected Route53 ChangeResourceRecordSets to be called")
+	if !created {
+		t.Error("expected created=true when the NS record did not exist (loop-guard signal)")
 	}
 	change := f.input.ChangeBatch.Changes[0]
-	if change.Action != types.ChangeActionUpsert {
-		t.Errorf("expected UPSERT, got %v", change.Action)
+	if change.Action != types.ChangeActionUpsert || change.ResourceRecordSet.Type != types.RRTypeNs {
+		t.Errorf("expected NS UPSERT, got %v %v", change.Action, change.ResourceRecordSet.Type)
 	}
-	rrs := change.ResourceRecordSet
-	if rrs.Type != types.RRTypeNs {
-		t.Errorf("expected NS record, got %v", rrs.Type)
+	if len(change.ResourceRecordSet.ResourceRecords) != 2 || *f.input.HostedZoneId != "ZPARENT" {
+		t.Errorf("unexpected change: %+v", change.ResourceRecordSet)
 	}
-	if *rrs.Name != "acct.compute.pennsieve.net" {
-		t.Errorf("unexpected record name %q", *rrs.Name)
+}
+
+func TestEnsureZoneDelegation_NotCreatedWhenPresent(t *testing.T) {
+	// Already delegated (trailing dot as Route53 returns it) → created=false so
+	// the caller won't re-trigger phase-2 provisioning in a loop.
+	f := &fakeRoute53{existing: []types.ResourceRecordSet{nsRRS("acct.compute.pennsieve.net.")}}
+	created, err := EnsureZoneDelegation(context.Background(), f, "ZPARENT", "acct.compute.pennsieve.net", []string{"ns-1.aws"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(rrs.ResourceRecords) != 2 {
-		t.Fatalf("expected 2 name servers, got %d", len(rrs.ResourceRecords))
+	if created {
+		t.Error("expected created=false when the NS record already exists")
 	}
-	if *f.input.HostedZoneId != "ZPARENT" {
-		t.Errorf("unexpected parent zone %q", *f.input.HostedZoneId)
+	if !f.called {
+		t.Error("should still UPSERT (refresh) even when present")
 	}
 }
 
 func TestEnsureZoneDelegation_PropagatesError(t *testing.T) {
 	f := &fakeRoute53{err: errors.New("boom")}
-	err := EnsureZoneDelegation(context.Background(), f, "ZPARENT", "acct.compute.pennsieve.net", []string{"ns-1.aws"})
+	_, err := EnsureZoneDelegation(context.Background(), f, "ZPARENT", "acct.compute.pennsieve.net", []string{"ns-1.aws"})
 	if err == nil {
 		t.Fatal("expected error to propagate")
 	}
+}
+
+func TestRemoveZoneDelegation(t *testing.T) {
+	t.Run("deletes when present", func(t *testing.T) {
+		f := &fakeRoute53{existing: []types.ResourceRecordSet{nsRRS("acct.compute.pennsieve.net.")}}
+		if err := RemoveZoneDelegation(context.Background(), f, "ZPARENT", "acct.compute.pennsieve.net"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !f.called || f.input.ChangeBatch.Changes[0].Action != types.ChangeActionDelete {
+			t.Errorf("expected a DELETE change, got called=%v", f.called)
+		}
+	})
+	t.Run("no-op when absent", func(t *testing.T) {
+		f := &fakeRoute53{} // nothing existing
+		if err := RemoveZoneDelegation(context.Background(), f, "ZPARENT", "acct.compute.pennsieve.net"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if f.called {
+			t.Error("expected no DELETE when the record is absent")
+		}
+	})
+	t.Run("no-op on empty args", func(t *testing.T) {
+		f := &fakeRoute53{}
+		_ = RemoveZoneDelegation(context.Background(), f, "", "acct.compute.pennsieve.net")
+		if f.called {
+			t.Error("expected no-op on empty parent zone")
+		}
+	})
 }

--- a/terraform/accounts-service.yml
+++ b/terraform/accounts-service.yml
@@ -347,6 +347,10 @@ components:
         enableLLMAccess:
           type: boolean
           description: Enable or disable LLM/Bedrock access for processors
+        maxInteractiveSessions:
+          type: integer
+          minimum: 0
+          description: Enable/disable interactive (Jupyter) sessions on an existing node. >0 enables (re-applies shared ALB + DNS); 0 disables.
     computeNodePermissionsRequest:
       type: object
       required:

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -539,19 +539,42 @@ data "aws_iam_policy_document" "eventbridge_handler_iam_policy_document" {
     ]
   }
 
-  # Upsert the NS delegation record for interactive-session subdomains in the
-  # Pennsieve parent hosted zone. Scoped to the configured parent zone only.
+  # Upsert/remove the NS delegation record for interactive-session subdomains in
+  # the Pennsieve parent hosted zone. Scoped to the configured parent zone only.
   statement {
     sid    = "EventBridgeHandlerInteractiveDNSDelegation"
     effect = "Allow"
     actions = [
       "route53:ChangeResourceRecordSets",
+      "route53:ListResourceRecordSets",
       "route53:GetChange"
     ]
     resources = [
       try(aws_route53_zone.interactive_parent[0].arn, "arn:aws:route53:::hostedzone/none"),
       "arn:aws:route53:::change/*"
     ]
+  }
+
+  # Auto-trigger interactive phase 2: after creating the NS delegation, the
+  # handler launches an UPDATE re-provision so the provisioner completes ACM
+  # validation + the HTTPS listener (which it skipped on the first pass to avoid
+  # deadlocking on an undelegated zone). Mirrors the service lambda's ECS perms.
+  statement {
+    sid    = "EventBridgeHandlerReprovision"
+    effect = "Allow"
+    actions = [
+      "ecs:RunTask",
+      "ecs:DescribeTaskDefinition",
+      "ecs:RegisterTaskDefinition"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid       = "EventBridgeHandlerPassRole"
+    effect    = "Allow"
+    actions   = ["iam:PassRole"]
+    resources = ["*"]
   }
 
 }

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -93,6 +93,15 @@ resource "aws_lambda_function" "eventbridge_handler_lambda" {
       # Parent zone (compute.pennsieve.net) for interactive-session subdomain
       # NS delegation. Empty disables delegation (no-op).
       INTERACTIVE_PARENT_ZONE_ID = try(aws_route53_zone.interactive_parent[0].zone_id, "")
+      INTERACTIVE_PARENT_DOMAIN  = var.interactive_parent_domain
+      # Provisioner-launch config — the handler auto-triggers interactive phase 2
+      # (UPDATE re-provision) after it creates the NS delegation. Mirrors the
+      # service lambda. Empty/unset → the handler logs + skips (graceful).
+      ACCOUNTS_TABLE          = aws_dynamodb_table.accounts_table.name
+      CLUSTER_ARN             = data.terraform_remote_state.fargate.outputs.ecs_cluster_arn
+      SUBNET_IDS              = join(",", data.terraform_remote_state.vpc.outputs.private_subnet_ids)
+      SECURITY_GROUP          = data.terraform_remote_state.platform_infrastructure.outputs.rehydration_fargate_security_group_id
+      TASK_DEF_CONTAINER_NAME = var.tier
     }
   }
 }


### PR DESCRIPTION
Follow-up to #67 (merged): add `maxInteractiveSessions` to the **update-config** path.

#67 wired create + `PUT /compute-nodes`, but the admin UI changes a node's capabilities (GPU/LLM, and now interactive) via **`POST /compute-nodes/{id}/update-config`** — which didn't handle interactive. This closes that gap so an operator can enable/disable interactive on an **existing** node (the path the pennsieve-app management UI uses), mirroring GPU.

- `UpdateConfigRequest` gains `MaxInteractiveSessions *int` (+ validation); persisted on the node.
- Re-provisioning task env now also gets `MAX_INTERACTIVE_SESSIONS` + `ENABLE_INTERACTIVE` (derived from >0), alongside the GPU/LLM vars.
- OpenAPI `updateConfigRequest` updated.

Paired with pennsieve-app #725 (Create dialog toggle + management-section rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
