### PR TITLE
Populate maxInteractiveSessions in compute-node GET + list responses

### DIFF
--- a/internal/handler/compute/get_compute_node_handler.go
+++ b/internal/handler/compute/get_compute_node_handler.go
@@ -179,10 +179,11 @@ func GetComputeNodeHandler(ctx context.Context, request events.APIGatewayV2HTTPR
 		DeploymentMode:      computeNode.DeploymentMode,
 		EnableLLMAccess:     computeNode.EnableLLMAccess,
 		LlmBaaAcknowledged:  computeNode.LlmBaaAcknowledged,
-		MaxGpuInstances:     computeNode.MaxGpuInstances,
-		GpuTier:             computeNode.GpuTier,
-		AccessScope:        accessScope,
-		Status:             nodeStatus,
+		MaxGpuInstances:        computeNode.MaxGpuInstances,
+		GpuTier:                computeNode.GpuTier,
+		MaxInteractiveSessions: computeNode.MaxInteractiveSessions,
+		AccessScope:            accessScope,
+		Status:                 nodeStatus,
 	})
 	if err != nil {
 		log.Println(err.Error())

--- a/internal/mappers/mappers.go
+++ b/internal/mappers/mappers.go
@@ -66,12 +66,13 @@ func DynamoDBNodeToJsonNodeWithAccountInfo(dynamoNodes []models.DynamoDBNode, ac
 			DeploymentMode:      c.DeploymentMode,
 			EnableLLMAccess:     c.EnableLLMAccess,
 			LlmBaaAcknowledged:  c.LlmBaaAcknowledged,
-			MaxGpuInstances:     c.MaxGpuInstances,
-			GpuTier:             c.GpuTier,
-			AccessScope:         accessScope,
-			Status:              nodeStatus,
-			HealthStatus:        c.HealthStatus,
-			LastHealthCheck:     c.LastHealthCheck,
+			MaxGpuInstances:        c.MaxGpuInstances,
+			GpuTier:                c.GpuTier,
+			MaxInteractiveSessions: c.MaxInteractiveSessions,
+			AccessScope:            accessScope,
+			Status:                 nodeStatus,
+			HealthStatus:           c.HealthStatus,
+			LastHealthCheck:        c.LastHealthCheck,
 		})
 	}
 
@@ -108,11 +109,12 @@ func DynamoDBNodeToJsonNode(dynamoNodes []models.DynamoDBNode) []models.Node {
 			DeploymentMode:      c.DeploymentMode,
 			EnableLLMAccess:     c.EnableLLMAccess,
 			LlmBaaAcknowledged:  c.LlmBaaAcknowledged,
-			MaxGpuInstances:     c.MaxGpuInstances,
-			GpuTier:             c.GpuTier,
-			Status:              c.Status,
-			HealthStatus:        c.HealthStatus,
-			LastHealthCheck:     c.LastHealthCheck,
+			MaxGpuInstances:        c.MaxGpuInstances,
+			GpuTier:                c.GpuTier,
+			MaxInteractiveSessions: c.MaxInteractiveSessions,
+			Status:                 c.Status,
+			HealthStatus:           c.HealthStatus,
+			LastHealthCheck:        c.LastHealthCheck,
 		})
 	}
 


### PR DESCRIPTION
## Problem
The compute-node details page shows **Interactive Notebooks: Disabled** even for nodes that have interactive enabled.

Root cause: the `Node` response DTO carries `maxInteractiveSessions` (no `omitempty`, always serialized), but **neither the single-node GET handler nor the list mappers set it** — so the API returned `maxInteractiveSessions: 0` for *every* node regardless of the stored value.

## Evidence (dev)
Node `47dc4458` ("Pennsieve - Interactive Compute"):
- DynamoDB (`dev-compute-resource-nodes-table-use1`, strongly-consistent): `maxInteractiveSessions = 2`
- API `GET /compute/resources/compute-nodes/{id}`: `maxInteractiveSessions = 0`

## Fix
Map `MaxInteractiveSessions` from the DynamoDB record in `GetComputeNodeHandler` (single GET) and in `DynamoDBNodeToJsonNodeWithAccountInfo` + `DynamoDBNodeToJsonNode` (list).

After deploy, the details page shows "Enabled / Max Sessions: N" and the notebook launcher's `interactiveCapable` filter gates on real values.

## Notes
- Scoped to the response mapping (plus gofmt alignment); no model/store changes.
- Separate follow-up: the workflow-service run gate keys interactive off per-run `processorConfigs` merged into the DAG, so a `maxInteractiveSessions=0` node isn't hard-rejected — tracked independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)