### PR TITLE
feat(interactive): tear down shared interactive infra when last interactive node goes away

### DIFF
--- a/internal/handler/compute/delete_compute_node_handler.go
+++ b/internal/handler/compute/delete_compute_node_handler.go
@@ -200,6 +200,24 @@ func DeleteComputeNodeHandler(ctx context.Context, request events.APIGatewayV2HT
 	roleNameKey := "ROLE_NAME"
 	roleNameValue := account.RoleName
 
+	// If this node is interactive and it's the LAST interactive node in the
+	// account, tell the provisioner to tear down the shared interactive infra
+	// (ALB + zone + cert + listener) on this same delete run. When other nodes
+	// remain the provisioner keeps the shared VPC/NAT; when this is the last node
+	// overall, its full shared destroy removes everything regardless of this flag.
+	// Fail safe: on any uncertainty, leave it false (never wrongly destroy infra
+	// another node depends on).
+	destroyInteractiveKey := "DESTROY_INTERACTIVE"
+	destroyInteractiveValue := "false"
+	if computeNode.MaxInteractiveSessions > 0 {
+		otherInteractive, err := accountHasInteractiveExcept(ctx, dynamo_store, computeNode.AccountUuid, computeNode.Uuid)
+		if err != nil {
+			log.Printf("Warning: could not determine remaining interactive nodes for account %s; not tearing down interactive infra: %v", computeNode.AccountUuid, err)
+		} else if !otherInteractive {
+			destroyInteractiveValue = "true"
+		}
+	}
+
 	runTaskIn := &ecs.RunTaskInput{
 		TaskDefinition: aws.String(TaskDefinitionArn),
 		Cluster:        aws.String(cluster),
@@ -266,6 +284,10 @@ func DeleteComputeNodeHandler(ctx context.Context, request events.APIGatewayV2HT
 						{
 							Name:  &roleNameKey,
 							Value: &roleNameValue,
+						},
+						{
+							Name:  &destroyInteractiveKey,
+							Value: &destroyInteractiveValue,
 						},
 					},
 				},

--- a/internal/handler/compute/interactive_teardown.go
+++ b/internal/handler/compute/interactive_teardown.go
@@ -1,0 +1,31 @@
+package compute
+
+import (
+	"context"
+
+	"github.com/pennsieve/account-service/internal/store_dynamodb"
+)
+
+// accountHasInteractiveExcept reports whether any node in the account — other
+// than excludeUuid — currently has interactive sessions enabled.
+//
+// Used to decide whether removing/disabling interactive on one node leaves the
+// account's shared interactive infrastructure unused. When it returns false, the
+// caller sets DESTROY_INTERACTIVE=true on the node's own provisioner run so the
+// provisioner tears down the (now unused) shared interactive infra. Pass the
+// empty string for excludeUuid to consider every node.
+func accountHasInteractiveExcept(ctx context.Context, nodeStore store_dynamodb.NodeStore, accountUuid, excludeUuid string) (bool, error) {
+	nodes, err := nodeStore.GetByAccount(ctx, accountUuid)
+	if err != nil {
+		return false, err
+	}
+	for _, n := range nodes {
+		if n.Uuid == excludeUuid {
+			continue
+		}
+		if n.MaxInteractiveSessions > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/handler/compute/post_update_config_handler.go
+++ b/internal/handler/compute/post_update_config_handler.go
@@ -234,6 +234,23 @@ func PostUpdateConfigHandler(ctx context.Context, request events.APIGatewayV2HTT
 		enableInteractive = "true"
 	}
 
+	// If this request explicitly DISABLES interactive on the node (sets it to 0)
+	// and no other node in the account still has it enabled, tear down the (now
+	// unused) shared interactive infra on this same re-provision (the shared
+	// module is otherwise sticky and would keep it). Gated on the request actually
+	// touching interactive so unrelated updates (e.g. GPU config) on non-
+	// interactive nodes never carry a teardown signal. Fail safe: leave it false
+	// on uncertainty.
+	destroyInteractive := "false"
+	if req.MaxInteractiveSessions != nil && *req.MaxInteractiveSessions == 0 {
+		otherInteractive, err := accountHasInteractiveExcept(ctx, nodesStore, computeNode.AccountUuid, computeNode.Uuid)
+		if err != nil {
+			log.Printf("Warning: could not determine remaining interactive nodes for account %s; not tearing down interactive infra: %v", computeNode.AccountUuid, err)
+		} else if !otherInteractive {
+			destroyInteractive = "true"
+		}
+	}
+
 	env := buildEnvVars(map[string]string{
 		"COMPUTE_NODE_ID":          nodeUuid,
 		"ENV":                      envValue,
@@ -257,6 +274,7 @@ func PostUpdateConfigHandler(ctx context.Context, request events.APIGatewayV2HTT
 		"GPU_TIER":                 computeNode.GpuTier,
 		"MAX_INTERACTIVE_SESSIONS": strconv.Itoa(computeNode.MaxInteractiveSessions),
 		"ENABLE_INTERACTIVE":       enableInteractive,
+		"DESTROY_INTERACTIVE":      destroyInteractive,
 		"ROLE_NAME":                account.RoleName,
 	})
 


### PR DESCRIPTION
## Summary

Tear down an account's **shared interactive infrastructure** (ALB + delegated zone + cert + HTTPS listener) when its **last interactive node** is removed or disabled.

The shared interactive infra is account-scoped, and the provisioner now keeps it *sticky* (a routine node apply never removes it). So removal must be explicit — and account-service is the only component that knows whether any interactive node remains for an account. It makes that decision here and signals the provisioner via `DESTROY_INTERACTIVE` on the node's **own** provisioner run (no separate task, no surviving-node hijack, no loop).

## Changes

- **`accountHasInteractiveExcept(account, excludeUuid)`** — does any *other* node in the account still have interactive enabled? Fail-safe to `true` on error, so we never wrongly tear down infra another node depends on.
- **`delete_compute_node_handler`** — when deleting the account's last interactive node, set `DESTROY_INTERACTIVE=true` on the `DELETE` task. (Last node overall still hits the provisioner's existing full shared-destroy.)
- **`post_update_config_handler`** — when an update disables the last interactive node, set `DESTROY_INTERACTIVE=true` on that node's re-provision.

## Dependency

Requires the provisioner change that honors `DESTROY_INTERACTIVE`: Pennsieve/compute-node-aws-provisioner-v2#29. This PR is safe to merge independently (it only sets an env var), but the teardown only takes effect once that ships.

## Testing

`go build ./...` and `go vet ./internal/handler/compute/` clean. Docker-based integration suite (`make test`) not run in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
