### PR TITLE
fix(iam): grant provisioner task role Route53 read for delegation gate

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -441,6 +441,30 @@ data "aws_iam_policy_document" "provisioner_fargate_iam_policy_document" {
     ]
   }
 
+  # Read the interactive-session NS delegation from the Pennsieve parent hosted
+  # zone. The provisioner gates phase 2 (ACM validation + HTTPS listener) on the
+  # per-account zone being delegated; it must read that delegation
+  # AUTHORITATIVELY via the Route53 API rather than a DNS lookup, because the
+  # provisioner's VPC attaches a private pennsieve.net zone that shadows
+  # compute.pennsieve.net (net.LookupNS there returns NXDOMAIN even when the
+  # public delegation is live). ListHostedZonesByName has no resource-level
+  # support, so it must be "*"; the record read is scoped to the parent zone.
+  statement {
+    sid       = "ProvisionerInteractiveDNSDelegationRead"
+    effect    = "Allow"
+    actions   = ["route53:ListHostedZonesByName"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid     = "ProvisionerInteractiveDNSDelegationRecordRead"
+    effect  = "Allow"
+    actions = ["route53:ListResourceRecordSets"]
+    resources = [
+      try(aws_route53_zone.interactive_parent[0].arn, "arn:aws:route53:::hostedzone/none"),
+    ]
+  }
+
 }
 
 # EventBridge Handler Lambda IAM Role


### PR DESCRIPTION
## Why

Companion to [compute-node-aws-provisioner-v2#31](https://github.com/Pennsieve/compute-node-aws-provisioner-v2/pull/31).

The provisioner gates interactive phase 2 (ACM validation + the shared HTTPS listener) on whether the per-account zone `{accountKey}.compute.pennsieve.net` is delegated. It previously checked this with `net.LookupNS`, but the provisioner's VPC attaches a **private `pennsieve.net` zone** that shadows the namespace, so the lookup returned NXDOMAIN inside the VPC and the listener was never created. The provisioner now reads the delegation **authoritatively via the Route53 API** on the parent zone — which requires the task role to have Route53 read.

## Change

Two read-only statements on the provisioner Fargate task role (`provisioner_fargate_task_iam_role`):

- `route53:ListHostedZonesByName` on `*` — this action has no resource-level support; used to discover the parent zone by name.
- `route53:ListResourceRecordSets` scoped to `aws_route53_zone.interactive_parent` — to read the `{accountKey}.compute.pennsieve.net` NS delegation record.

No new resources; the record read is scoped to the parent zone. No permissions boundary involved (account-service uses none, and this role is unbounded).

## Ordering

Apply this **before** (or together with) the provisioner release. Until it lands, the provisioner's gate fails closed (no listener created = current behavior, never destructive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)