### PR TITLE
fix(compute): forward DEPLOYMENT_MODE on node delete

### DIFF
--- a/internal/handler/compute/delete_compute_node_handler.go
+++ b/internal/handler/compute/delete_compute_node_handler.go
@@ -199,6 +199,16 @@ func DeleteComputeNodeHandler(ctx context.Context, request events.APIGatewayV2HT
 	nodeNameValue := computeNode.Name
 	roleNameKey := "ROLE_NAME"
 	roleNameValue := account.RoleName
+	// DEPLOYMENT_MODE must be forwarded on DELETE too: the provisioner gates its
+	// shared-infrastructure teardown (last-node VPC/NAT destroy AND the
+	// DESTROY_INTERACTIVE interactive teardown below) on deployment_mode=="secure".
+	// Without this the provisioner defaults to "basic" and skips that teardown
+	// entirely, leaking the shared ALB/zone/cert (and VPC/NAT on the last node).
+	deploymentModeKey := "DEPLOYMENT_MODE"
+	deploymentModeValue := computeNode.DeploymentMode
+	if deploymentModeValue == "" {
+		deploymentModeValue = "basic"
+	}
 
 	// If this node is interactive and it's the LAST interactive node in the
 	// account, tell the provisioner to tear down the shared interactive infra
@@ -284,6 +294,10 @@ func DeleteComputeNodeHandler(ctx context.Context, request events.APIGatewayV2HT
 						{
 							Name:  &roleNameKey,
 							Value: &roleNameValue,
+						},
+						{
+							Name:  &deploymentModeKey,
+							Value: &deploymentModeValue,
 						},
 						{
 							Name:  &destroyInteractiveKey,


### PR DESCRIPTION
## Bug

The delete handler (`delete_compute_node_handler.go`) forwards every provisioner env var **except `DEPLOYMENT_MODE`**. The provisioner defaults it to `basic` (`main.go`), so **every DELETE runs as basic — even for secure nodes** (observed live: a secure node's DELETE task logged "Deployment Mode: BASIC").

The provisioner's `delete()` gates its **entire shared-infrastructure teardown** on `deployment_mode == "secure"`:

```go
if p.DeploymentMode == "secure" {
    if !p.hasOtherNodeStates(...) { destroySharedInfrastructure(...) }  // last-node VPC/NAT
    else if p.DestroyInteractive { ensureSharedInfrastructure(...) }     // interactive teardown
}
```

Running delete as `basic` silently skips that whole block, so:
1. **`DESTROY_INTERACTIVE` never fires** — the handler computes and passes it, but the provisioner never consults it → deleting the last interactive node leaves the shared ALB/zone/cert behind.
2. **Last-node VPC/NAT teardown never fires** → the shared VPC/NAT leaks when the last node is deleted.

The create / update / update-config / reprovision-phase2 handlers all pass `DEPLOYMENT_MODE`; the delete handler was the lone outlier.

## Fix

Forward `DEPLOYMENT_MODE` from the stored node (default `basic`), mirroring the other handlers. Per-node `terraform destroy` is state-driven and unaffected; this only re-enables the secure-mode shared-teardown path so the `DESTROY_INTERACTIVE` trigger and last-node cleanup actually run.

Build + vet pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)