### PR TITLE
feat(delete): use latest provisioner image for teardown, not the pinned tag

### DIFF
--- a/internal/handler/compute/delete_compute_node_handler.go
+++ b/internal/handler/compute/delete_compute_node_handler.go
@@ -114,12 +114,19 @@ func DeleteComputeNodeHandler(ctx context.Context, request events.APIGatewayV2HT
 		}, nil
 	}
 
-	// Use provisioner image from the stored compute node, with defaults
+	// Teardown uses the LATEST provisioner image, not the node's pinned
+	// provision-time tag. Pinning exists for reproducible PROVISIONING; DELETE
+	// wants the newest teardown logic so fixes (shared-VPC resolution, ENI
+	// draining, interactive-task reaping) apply to EVERY existing node regardless
+	// of when it was created — otherwise an old-pinned node carries its
+	// provisioning-era delete bugs forever and can't be torn down without a manual
+	// tag bump. Overridable via PROVISIONER_TEARDOWN_IMAGE_TAG to pin a known-good
+	// teardown build. The image repo still comes from the node (custom repos).
 	provisionerImage := computeNode.ProvisionerImage
 	if provisionerImage == "" {
 		provisionerImage = "pennsieve/compute-node-aws-provisioner-v2"
 	}
-	provisionerImageTag := computeNode.ProvisionerImageTag
+	provisionerImageTag := os.Getenv("PROVISIONER_TEARDOWN_IMAGE_TAG")
 	if provisionerImageTag == "" {
 		provisionerImageTag = "latest"
 	}


### PR DESCRIPTION
## Why

DELETE built the provisioner task def from the node's **stored** `provisionerImageTag` (its provision-time pin). So a node pinned to an old provisioner carried that version's delete bugs **forever** and couldn't be torn down until its tag was manually bumped — e.g. v1.6.0–v1.6.2 nodes were un-deletable until the StateBucket/DEPLOYMENT_MODE fixes landed, and we had to hand-edit DynamoDB to delete `47dc4458`.

Pinning is for reproducible **provisioning**; **teardown** should always use the newest logic (shared-VPC resolution, ENI draining, interactive-task reaping) so fixes apply to every existing node.

## Change

DELETE now uses `PROVISIONER_TEARDOWN_IMAGE_TAG` (default `latest`) instead of the node's pinned tag. The image **repo** still comes from the node (custom repos). Per-node `terraform destroy` is state-driven, so the newer image's config reconciles against the existing state.

Pairs with the provisioner delete() fixes (StateBucket resolution v1.6.3, interactive-kernel reaping). With this, deleting any old node just works once `:latest` carries the fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)