### PR TITLE
feat(delete): reject delete of a node with active runs (409 via gateway)

### DIFF
--- a/internal/handler/compute/active_runs.go
+++ b/internal/handler/compute/active_runs.go
@@ -1,0 +1,44 @@
+package compute
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/pennsieve/account-service/internal/clients"
+	"github.com/pennsieve/account-service/internal/models"
+)
+
+// activeExecutionsViaGateway asks the node's gateway GET /health for the count of
+// RUNNING workflow executions on the node (workflows AND interactive sessions —
+// both are Step Functions executions).
+//
+// Returns (count, true) when the gateway reported a value, or (0, false) when the
+// count is UNKNOWN: no gateway URL, gateway unreachable, an older gateway that
+// doesn't report sfnActiveExecutions, or an unparseable response. Callers gate
+// node deletes on this; "unknown" fails OPEN (proceed) because the provisioner's
+// delete() active-execution check is the authoritative backstop — this gateway
+// check only exists to reject the delete up front with a friendly 409.
+func activeExecutionsViaGateway(ctx context.Context, gatewayURL, region string, cfg aws.Config) (int, bool) {
+	if gatewayURL == "" {
+		return 0, false
+	}
+	client := clients.NewProvisionerClient(gatewayURL, region, cfg)
+	body, err := client.Get(ctx, "/health")
+	if err != nil {
+		log.Printf("active-run gate: gateway health call failed (failing open): %v", err)
+		return 0, false
+	}
+	trimmed := string(body)
+	if trimmed == "" || trimmed == "null" {
+		// Old gateway without a /health implementation.
+		return 0, false
+	}
+	var health models.HealthCheckResponse
+	if err := json.Unmarshal(body, &health); err != nil {
+		log.Printf("active-run gate: could not parse gateway health (failing open): %v", err)
+		return 0, false
+	}
+	return health.Resources.SFNActiveExecutions, true
+}

--- a/internal/handler/compute/delete_compute_node_handler.go
+++ b/internal/handler/compute/delete_compute_node_handler.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"strings"
 
+	"fmt"
+
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -129,6 +131,19 @@ func DeleteComputeNodeHandler(ctx context.Context, request events.APIGatewayV2HT
 	provisionerImageTag := os.Getenv("PROVISIONER_TEARDOWN_IMAGE_TAG")
 	if provisionerImageTag == "" {
 		provisionerImageTag = "latest"
+	}
+
+	// Gate: refuse to delete a node with live work — running workflows OR
+	// interactive sessions (both are Step Functions executions). The authoritative
+	// count comes from the node's gateway /health. If it's unknown (old or
+	// unreachable gateway) we proceed and rely on the provisioner-side delete()
+	// active-execution check as the backstop.
+	if active, known := activeExecutionsViaGateway(ctx, computeNode.ComputeNodeGatewayUrl, cfg.Region, cfg); known && active > 0 {
+		log.Printf("Refusing delete of node %s: %d active execution(s) reported by gateway", uuid, active)
+		return events.APIGatewayV2HTTPResponse{
+			StatusCode: http.StatusConflict,
+			Body:       errors.ComputeHandlerError(handlerName, fmt.Errorf("compute node has %d active workflow execution(s) or interactive session(s) — cancel or wait for them to finish before deleting", active)),
+		}, nil
 	}
 
 	// Set node status to "Destroying" before launching the delete task

--- a/internal/models/health.go
+++ b/internal/models/health.go
@@ -9,14 +9,18 @@ const (
 
 // HealthCheckResponse is the parsed response from a gateway's GET /health endpoint.
 type HealthCheckResponse struct {
-	Status    string                `json:"status"`
-	Issues    []HealthCheckIssue    `json:"issues,omitempty"`
-	Resources HealthCheckResources  `json:"resources,omitempty"`
+	Status    string               `json:"status"`
+	Issues    []HealthCheckIssue   `json:"issues,omitempty"`
+	Resources HealthCheckResources `json:"resources,omitempty"`
 }
 
 // HealthCheckResources contains resource inventories from the gateway.
 type HealthCheckResources struct {
 	EFSLayers []EFSLayerInfo `json:"efsLayers,omitempty"`
+	// SFNActiveExecutions is the count of RUNNING workflow executions on the node
+	// (workflows + interactive sessions). Used to gate node deletion. Omitted by
+	// older gateways → treated as "unknown" (gate fails open to the provisioner backstop).
+	SFNActiveExecutions int `json:"sfnActiveExecutions,omitempty"`
 }
 
 // EFSLayerInfo describes a layer on EFS as reported by the gateway health check.


### PR DESCRIPTION
## Why

Completes the delete-robustness work. Today a delete with live work returns `202` and is only refused later by the provisioner (or, before the recent fixes, hung the teardown). This adds the **friendly up-front guard**: deleting a node with a running workflow or interactive session fails fast with **409 Conflict**.

## How

Before setting the node `Destroying`, the delete handler asks the node's gateway `GET /health` for `resources.sfnActiveExecutions` (RUNNING workflows **and** interactive sessions — both are Step Functions executions). If any are running → `409` with a clear message.

- New `activeExecutionsViaGateway` reuses the existing SigV4 `ProvisionerClient` + `HealthCheckResponse` that the healthchecker already uses — no new channel or auth.
- **Fails open** when the count is unknown (no gateway URL, unreachable, or an older gateway that doesn't report it). The provisioner-side `delete()` active-execution check (PR compute-node-aws-provisioner-v2#33) is the authoritative backstop; this is purely the nicer UX layer.
- `HealthCheckResources` gains `SFNActiveExecutions` (the gateway already emits `resources.sfnActiveExecutions`).

## Notes

Builds + vets clean. The compute package's integration tests require local DynamoDB (`make test` / Docker Compose) — run in CI.

This is the last item from the delete-robustness plan:
- account-service: #71 (route53 IAM), #72 (DEPLOYMENT_MODE on delete), #73 (delete uses latest image), **this** (409 gate)
- provisioner: #31/v1.6.2 (route53 delegation), #32/v1.6.3 (StateBucket), #33/v1.6.4 (reap + provisioner gate + destroy retry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)