### PR TITLE
docs: plan for typed compute-node layers + run environment provenance

### DIFF
--- a/docs/compute-node-layers-implementation.md
+++ b/docs/compute-node-layers-implementation.md
@@ -65,34 +65,45 @@ versions + `pythonVersion: 3.12`, readable via the layers API.
 
 ---
 
-## M3 — Safe consume-side wiring (runtime wrapper)
+## M3 — Safe consume-side wiring
 
-**Goal:** a `python-env` layer is importable without consumer hardcoding, **without
-clobbering** the image's own `PYTHONPATH`.
+**Goal:** a `python-env` layer is importable without clobbering the image's own `PYTHONPATH`
+— and **without forcing user processors onto a Pennsieve base image.**
 
-**Mechanism (settled):** an **in-image entrypoint wrapper**, not a converter override. A
-Pennsieve processor base image (or a drop-in 2-line entrypoint snippet) that, before exec'ing
-the real command: reads `LAYERS_DIR` (already injected — *no converter change*), **globs** each
-mounted layer's `lib/python*/site-packages` and **appends** them to `PYTHONPATH`, sets
-`PYTHONPYCACHEPREFIX=/tmp/pycache`, then `exec "$@"`. Runtime shell expansion = append-safe
-(preserves the image's own `PYTHONPATH`); the glob makes it version-agnostic (no need to thread
-the manifest version through the converter). **Opt-in** (D3): processors on the base/snippet get
-auto-wiring; others keep the `LAYERS_DIR` self-wiring contract.
+**Hard limit:** there's no way to auto-append `PYTHONPATH` from *outside* a container (ECS
+overrides replace, not append — #34; and we don't know an arbitrary image's `CMD` to wrap it).
+The append must run *inside* the container at startup. So auto-wiring is **only free where
+Pennsieve owns the image**; everywhere else it's the existing self-wiring contract.
+
+**Tiered (settled):**
+
+| Consumer | Mechanism | Burden |
+|---|---|---|
+| **Pennsieve-managed** images (python-session & R-session kernels, `pennsieve-quick-plot`, `notebook-runner`) | wrapper **baked into the image**: globs `LAYERS_DIR` layers' `lib/python*/site-packages`, **appends** to `PYTHONPATH`, sets `PYTHONPYCACHEPREFIX=/tmp/pycache`, then `exec "$@"` (append-safe via runtime shell; version-agnostic via glob; **no converter change**) | none — Pennsieve owns it |
+| **User processor, wants convenience** | copy a ~3-line **entrypoint snippet** (keeps their own base image) | tiny, opt-in |
+| **User processor, minimal** | **self-wire** from `LAYERS_DIR` (`sys.path.insert`) — the universal contract, works on any image | a few lines of code |
+
+In practice this covers **every current env-layer consumer** (all Pennsieve-managed) with zero
+user coupling; the snippet/self-wiring is only for a user building their *own* processor against
+a Pennsieve env layer.
 
 **Tasks**
-- New Pennsieve processor **base image** (or entrypoint snippet) implementing the glob+append
-  wrapper above.
+- Implement the glob+append wrapper in the **Pennsieve-managed** session/app images
+  (python-session, R-session, quick-plot, notebook-runner).
+- **App: surface the copy-paste snippet** — when a user attaches an env layer to their own
+  processor (or views a layer in the catalog), show the entrypoint snippet *and* the
+  `sys.path` self-wiring alternative, with the layer's `LAYERS_DIR` path filled in. (pennsieve-app
+  `ComputeNodeLayers.vue` / `LayerNameSelector.vue`.)
 - Compatibility check (D2): hard-fail at run submit when a layer's `pythonVersion` (manifest) ≠
   the processor's; warn in the selector.
-- Migrate `processor-build-python-layer` / `pennsieve-quick-plot` onto the base (or add the
-  snippet) to adopt — net-new processors start on it.
 
-**Acceptance:** a processor on the base image with a `python-env` layer imports its packages with
-no hardcoding, **and** an image that sets its own `PYTHONPATH` (e.g. `quick-plot`'s `/app`) still
-works (append, not clobber — regression guard).
+**Acceptance:** a Pennsieve-managed app with a `python-env` layer imports its packages with no
+hardcoding, **and** an image that sets its own `PYTHONPATH` (e.g. `quick-plot`'s `/app`) still
+works (append, not clobber). A user building their own processor sees, in the app, exactly what
+to copy-paste — no Pennsieve base image required.
 
 **Depends on:** M2. **Decisions:** D2, D3.
-*(Reference: the clobbering ECS-override approach was prototyped and rejected — provisioner #34; this in-image append wrapper is the fix.)*
+*(Reference: the clobbering ECS-override approach was prototyped and rejected — provisioner #34; the in-image append wrapper is the fix, scoped to Pennsieve-managed images.)*
 
 ---
 
@@ -240,7 +251,8 @@ unblocks everything. Then split: M3+M4+M5 (the provenance/usability spine) vs M6
 | Repo | Milestones |
 |---|---|
 | workflow-service | M1, M2, M4, M6, M8 |
-| compute-node-aws-provisioner-v2 (`data-transfer`, `aslconverter`, `workflow-finalizer`, gateway) | M1, M2, M3, M4, M7, M9 |
+| compute-node-aws-provisioner-v2 (`data-transfer`, `aslconverter`, `workflow-finalizer`, gateway) | M1, M2, M4, M7 |
 | account-service | M1 (model mirror), M6 (build-trigger API) |
 | processor-build-python-layer / new processor-build-r-layer | M2, M9 |
-| pennsieve-app (`Analysis/`) | M5, M6, M8, M10 |
+| Pennsieve-managed app/session images (python-session & R-session kernels, `pennsieve-quick-plot`, `notebook-runner`) | M3 (bake in the wrapper), M9 (R) |
+| pennsieve-app (`Analysis/`) | M3 (copy-paste snippet UI), M5, M6, M8, M10 |

--- a/docs/compute-node-layers-implementation.md
+++ b/docs/compute-node-layers-implementation.md
@@ -65,6 +65,35 @@ versions + `pythonVersion: 3.12`, readable via the layers API.
 
 ---
 
+## Layer mounting & visibility (how a layer reaches the container)
+
+Layers live **shared per compute node** at EFS `/data/{cni}/layers/{name}` (one dir per
+layer). But a run's container reads EFS through a **per-execution access point** rooted at
+`/data/{cni}/{eri}`, so the shared layers dir — a *sibling outside that root* — is not
+directly reachable. Getting a selected layer to the container:
+
+- The processor/interactive **task definition attaches a dedicated read-only EFS access
+  point** rooted at `/data/{cni}/layers`, mounted at **`/mnt/layers`** (provisioner:
+  `aws_efs_access_point.layers` + `registerTaskDefinition`).
+- **`mount-layers` symlinks each *selected* layer** into the run's `LAYERS_DIR`
+  (`/data/{cni}/{eri}/layers/{name}` → `/mnt/layers/{name}`). The container resolves the
+  link through its own `/mnt/layers` mount; the consume-side wiring (below) then globs
+  `LAYERS_DIR` and only ever sees the selected layers.
+- **Why not copy/hard-link:** hard-linking the layer files fails `EPERM` on EFS (they're
+  read-only), and a symlink straight to the shared dir dangles (outside the per-exec root).
+  A copy duplicates bytes per run. The read-only shared mount + symlink is **O(1), no
+  duplication, no `EPERM`** (provisioner #39 hard-link → #41 read-only AP mount).
+
+**Visibility / least-privilege (decided):** only *selected* layers are symlinked into
+`LAYERS_DIR` and wired onto `PYTHONPATH` — that's what a run *uses*. But `/mnt/layers`
+exposes **all of the node's layers read-only**, so a run *can read* layers it didn't
+select. This is accepted: layers are **shared, read-only, same-account** assets (compute
+nodes are account-scoped), not cross-tenant. Don't put per-run secrets in a layer expecting
+isolation. If a sensitive-data-layer case emerges, stage *selected* layers per-run (copy)
+instead of the shared mount — a deliberate trade-off against the O(1) shared mount.
+
+---
+
 ## M3 — Safe consume-side wiring
 
 **Goal:** a `python-env` layer is importable without clobbering the image's own `PYTHONPATH`

--- a/docs/compute-node-layers-implementation.md
+++ b/docs/compute-node-layers-implementation.md
@@ -18,7 +18,7 @@ Agreed before build; these shape multiple milestones.
 
 | # | Decision | **Settled** |
 |---|---|---|
-| D1 | **Layer versioning** | **Immutable snapshots (`{name}@{hash}`) for `python-env`/`r-env`** (a run references a stable env); **`data` layers overwrite in place**, guarded by an active-run check. |
+| D1 | **Layer versioning** | **Immutable snapshots (`{name}@{hash}`) for `python-env`/`r-env`** (a run references a stable env); **`data` layers overwrite in place**, guarded by an active-run check. **Snapshot id = short SHA-256 of the normalized resolved lock** (sorted `pip freeze`), computed at commit — content-addressed (rebuilding identical deps dedups; PyPI drift yields a new id). Hash the *resolved* lock, not the input `requirements.txt`. Manifest keeps `treeChecksum` for byte-integrity. |
 | D2 | **Compatibility enforcement** | **Hard-fail at run submit** on python/R version (or arch) mismatch; **warn earlier in the selector**. |
 | D3 | **Consume-side wiring** | **Keep consumer self-wiring from `LAYERS_DIR` as the contract; add an opt-in runtime entrypoint wrapper** that auto-appends `PYTHONPATH` from the manifest (never a clobbering env override). |
 | D4 | **Provenance home** | **Run record for v1; Discover dataset provenance later.** |
@@ -70,20 +70,29 @@ versions + `pythonVersion: 3.12`, readable via the layers API.
 **Goal:** a `python-env` layer is importable without consumer hardcoding, **without
 clobbering** the image's own `PYTHONPATH`.
 
-**Tasks**
-- Decide the wrapper mechanism (sub-decision): a small entrypoint shim the converter prepends
-  to the container command, OR an init that writes an env file the processor sources. It must
-  **append** `$LAYERS_DIR/{name}/lib/python{ver}/site-packages` (version from the manifest)
-  to the existing `PYTHONPATH`, and set `PYTHONPYCACHEPREFIX=/tmp/pycache`.
-- provisioner converter (`internal/aslconverter`): pass the resolved env-layer + its manifest
-  version to the wrapper (not via an ECS env override — see plan, "Consume-side wiring").
-- Compatibility check (D2): refuse/warn when layer `pythonVersion` ≠ the processor base.
+**Mechanism (settled):** an **in-image entrypoint wrapper**, not a converter override. A
+Pennsieve processor base image (or a drop-in 2-line entrypoint snippet) that, before exec'ing
+the real command: reads `LAYERS_DIR` (already injected — *no converter change*), **globs** each
+mounted layer's `lib/python*/site-packages` and **appends** them to `PYTHONPATH`, sets
+`PYTHONPYCACHEPREFIX=/tmp/pycache`, then `exec "$@"`. Runtime shell expansion = append-safe
+(preserves the image's own `PYTHONPATH`); the glob makes it version-agnostic (no need to thread
+the manifest version through the converter). **Opt-in** (D3): processors on the base/snippet get
+auto-wiring; others keep the `LAYERS_DIR` self-wiring contract.
 
-**Acceptance:** a processor with a `python-env` layer imports its packages with no hardcoding,
-**and** `pennsieve-quick-plot`'s `ENV PYTHONPATH=/app` still works (regression guard).
+**Tasks**
+- New Pennsieve processor **base image** (or entrypoint snippet) implementing the glob+append
+  wrapper above.
+- Compatibility check (D2): hard-fail at run submit when a layer's `pythonVersion` (manifest) ≠
+  the processor's; warn in the selector.
+- Migrate `processor-build-python-layer` / `pennsieve-quick-plot` onto the base (or add the
+  snippet) to adopt — net-new processors start on it.
+
+**Acceptance:** a processor on the base image with a `python-env` layer imports its packages with
+no hardcoding, **and** an image that sets its own `PYTHONPATH` (e.g. `quick-plot`'s `/app`) still
+works (append, not clobber — regression guard).
 
 **Depends on:** M2. **Decisions:** D2, D3.
-*(Reference: the clobbering ECS-override approach was prototyped and rejected — provisioner #34.)*
+*(Reference: the clobbering ECS-override approach was prototyped and rejected — provisioner #34; this in-image append wrapper is the fix.)*
 
 ---
 

--- a/docs/compute-node-layers-implementation.md
+++ b/docs/compute-node-layers-implementation.md
@@ -1,0 +1,236 @@
+# Compute Node Layers & Environment Provenance — Implementation Steps
+
+Companion to [`compute-node-layers-plan.md`](./compute-node-layers-plan.md) (the *what/why*).
+This is the *how/in-what-order* — a reviewable work breakdown. Each milestone lists the
+repos/files touched, acceptance criteria, and the decisions it forces. Milestones are
+ordered by dependency; several are independently shippable.
+
+> Scope note: the *current* compute-node project (interactive notebooks + delete robustness)
+> is done, and layers already work via the **consumer-self-wiring** contract (`read
+> LAYERS_DIR → sys.path`). Everything below is the **environments & provenance initiative** —
+> a deliberate follow-on, not a hotfix.
+
+---
+
+## Decisions to settle first (gate the build)
+
+These shape multiple milestones; agree on them before M1.
+
+| # | Decision | Options | Leaning |
+|---|---|---|---|
+| D1 | **Layer versioning** | overwrite-in-place vs immutable snapshot (`{name}@{hash}`) | snapshot for `python-env`/`r-env` (provenance refs them); overwrite OK for `data`, guarded by active-run check |
+| D2 | **Compatibility enforcement** | hard-fail vs warn at mount/select on python/R version mismatch | hard-fail at run submit; warn in selector |
+| D3 | **Consume-side wiring mechanism** | runtime entrypoint wrapper vs processor self-wiring (status quo) | keep self-wiring as the contract; add the wrapper as the centralized convenience (M3) |
+| D4 | **Provenance home** | run record only vs also Discover dataset provenance | run record for v1; Discover later |
+| D5 | **EFS import perf** | accept NFS imports vs stage layer → local at task start | accept for v1 (deps-on-base-image posture); revisit if cold-start hurts |
+| D6 | **Quota / GC** | per-node layer count/size cap + cleanup policy | define a cap before self-service (M6) |
+
+---
+
+## M1 — Layer type model (foundation)
+
+**Goal:** every layer carries a `layerType`; existing layers default to `data`. No behavior
+change yet.
+
+**Tasks**
+- workflow-service (`compute-node-layers` store/model): add `layerType` (default `data`),
+  `manifestKey`, `version`/`snapshotId`. Migration: backfill existing rows → `data`.
+- provisioner `cmd/data-transfer`: `persistent-layer` data-target accepts a `layerType`
+  param (alongside `layerName`); `commit-layer` persists it.
+- account-service `internal/models/health.go` (`LayerRecord`) + healthchecker reconcile:
+  mirror `layerType`.
+
+**Acceptance:** a newly committed layer records its `layerType`; existing layers read back as
+`data`; reconcile passes.
+
+**Decisions:** D1 (version field shape).
+
+---
+
+## M2 — Layer manifest (`python-env`)
+
+**Goal:** a built python-env layer self-describes (versions + python version + checksum).
+
+**Tasks**
+- processor-build-python-layer: emit `manifest.json` — `pythonVersion`, `platform`,
+  `packages` (from `pip freeze`), raw freeze. (Already a README TODO.)
+- provisioner `commit-layer`: store the builder's `manifest.json` with the layer; add
+  `sizeBytes`/`fileCount` (already computed) + `treeChecksum`. Write `manifestKey` to the record.
+- workflow-service: surface `manifestKey` + parsed summary on the layer record / list API.
+
+**Acceptance:** rebuilding `quick-plot-stack` produces a `manifest.json` with resolved
+versions + `pythonVersion: 3.12`, readable via the layers API.
+
+**Depends on:** M1. **Decisions:** D1.
+
+---
+
+## M3 — Safe consume-side wiring (runtime wrapper)
+
+**Goal:** a `python-env` layer is importable without consumer hardcoding, **without
+clobbering** the image's own `PYTHONPATH`.
+
+**Tasks**
+- Decide the wrapper mechanism (sub-decision): a small entrypoint shim the converter prepends
+  to the container command, OR an init that writes an env file the processor sources. It must
+  **append** `$LAYERS_DIR/{name}/lib/python{ver}/site-packages` (version from the manifest)
+  to the existing `PYTHONPATH`, and set `PYTHONPYCACHEPREFIX=/tmp/pycache`.
+- provisioner converter (`internal/aslconverter`): pass the resolved env-layer + its manifest
+  version to the wrapper (not via an ECS env override — see plan, "Consume-side wiring").
+- Compatibility check (D2): refuse/warn when layer `pythonVersion` ≠ the processor base.
+
+**Acceptance:** a processor with a `python-env` layer imports its packages with no hardcoding,
+**and** `pennsieve-quick-plot`'s `ENV PYTHONPATH=/app` still works (regression guard).
+
+**Depends on:** M2. **Decisions:** D2, D3.
+*(Reference: the clobbering ECS-override approach was prototyped and rejected — provisioner #34.)*
+
+---
+
+## M4 — Run-environment capture + endpoint
+
+**Goal:** every run records the exact environment that executed.
+
+**Tasks**
+- provisioner (entrypoint capture, uniform): image digest (`$ECS_CONTAINER_METADATA_URI_V4`),
+  mounted layer refs + **copied manifests**, processor source commit, and — interactive only —
+  live `pip freeze`. Write `environment.json` to `/mnt/efs/{cni}/{eri}/logs/{nodeId}/`.
+- provisioner `cmd/workflow-finalizer`: collect per-node `environment.json` → run-level
+  provenance bundle on the run record (workflow-service).
+- endpoint: `GET /compute/workflows/runs/{runId}/environment[?nodeId=]` (gateway /
+  workflow-service) — mirrors the existing per-node logs endpoint.
+
+**Acceptance:** a completed non-interactive run exposes image digest + layer versions; an
+interactive session additionally exposes the live freeze. Survives layer deletion (manifests
+are copied, not referenced).
+
+**Depends on:** M2 (manifests to copy). **Decisions:** D4.
+
+---
+
+## M5 — App MVP (view provenance)
+
+**Goal:** users can see a run's environment and browse layer details.
+
+**Tasks**
+- pennsieve-app `RunMonitor/RunDetail.vue`: clone the per-node **logs dialog**
+  (`openLogs`) into an **Environment** dialog (`openEnvironment` → M4 endpoint); per-node +
+  run-level; base image, versions, env layers, searchable package list, download lock.
+- pennsieve-app `ComputeNodes/ComputeNodeLayers.vue` + `computeResourcesStore`: **type
+  badge** + manifest detail (row-expand).
+
+**Acceptance:** from a run, a user opens "Environment" and sees what ran; the layer catalog
+shows type + contents.
+
+**Depends on:** M4 (endpoint), M2 (manifest for the catalog). **Decisions:** —
+
+---
+
+## M6 — Self-service env layers (`requirements.txt` → build)
+
+**Goal:** a user creates a python-env layer from a `requirements.txt` (basic/secure only).
+
+**Tasks**
+- account-service / workflow-service: build-trigger API — `{computeNode, layerName,
+  requirements.txt, pythonVersion}` → launch the build workflow (`python-layer-builder` +
+  `persistent-layer` target) on the node; track build status.
+- pennsieve-app `ComputeNodeLayers.vue`: extend the create-layer form to
+  `{name, requirements, pythonVersion}`; show a `BUILDING` state on the existing badge.
+- Quota/GC enforcement (D6).
+
+**Acceptance:** user submits a `requirements.txt` → layer builds on Fargate → shows READY →
+selectable; resolved lock captured (M2). Rejected on compliant nodes with a clear message.
+
+**Depends on:** M1, M2. **Decisions:** D1 (rebuild semantics), D6 (quota).
+
+---
+
+## M7 — Data layers (reference data)
+
+**Goal:** `data` layers are referenceable and show up as inputs, not environment.
+
+**Tasks**
+- provisioner converter: per-mounted-`data`-layer `LAYER_<NAME>_DIR` env var.
+- provenance: route `data` layers to the **inputs/reference-data** dimension of the run
+  record (identity from the manifest — version/source/treeChecksum).
+- (compliant) S3-staging path to populate a data layer's EFS dir via the gateway endpoint.
+
+**Acceptance:** a workflow references a genome via `LAYER_GENOME_DIR`; the run's provenance
+shows it under reference data by identity.
+
+**Depends on:** M1, M4. **Decisions:** —
+
+---
+
+## M8 — Selection rules + UX
+
+**Goal:** enforce "one env layer per processor; many data layers."
+
+**Tasks**
+- pennsieve-app `RunMonitor/LayerNameSelector.vue`: single-select for env layers, multi-select
+  for data; compatibility hint (D2).
+- workflow-service run submit: validate ≤1 `python-env` and ≤1 `r-env` per processor.
+
+**Acceptance:** selecting two env layers is rejected (UI + API); multiple data layers allowed.
+
+**Depends on:** M1. **Decisions:** D2.
+
+---
+
+## M9 — R env (parity)
+
+**Goal:** `r-env` layers, mirroring python.
+
+**Tasks**
+- new `processor-build-r-layer` (`renv`/`pak` → library dir; emit `renv.lock` manifest).
+- provisioner converter/wrapper: append to `R_LIBS_USER` (M3 mechanism).
+- catalog/selector: R badge + version.
+
+**Acceptance:** an R workflow consumes an `r-env` layer; provenance records `renv.lock` + R version.
+
+**Depends on:** M2, M3. **Decisions:** D2.
+
+---
+
+## M10 — Reproduce + notebook snapshot
+
+**Goal:** close the loop.
+
+**Tasks**
+- pennsieve-app: "re-run with this environment" on the RunDetail env dialog → pre-fill run
+  launch pinned to the captured image digest + layer versions.
+- pennsieve-app `JupyterSession/NotebookSession.vue`: "snapshot environment" / "save as
+  layer"; freeze at session end; embed in `.ipynb` metadata.
+
+**Acceptance:** a user re-runs a past run's exact environment; a notebook's environment is
+captured at session end and embedded in the saved notebook.
+
+**Depends on:** M4, M5, M6. **Decisions:** D4 (reproduce/provenance scope).
+
+---
+
+## Suggested sequencing
+
+```
+M1 ─▶ M2 ─▶ M3 (wiring)        ─┐
+            M4 (capture) ─▶ M5 (app view) ─▶ M10 (reproduce)
+M1 ─▶ M2 ─────────────────▶ M6 (self-service)
+M1 ─────────────────────▶ M7 (data) , M8 (selection)
+M2, M3 ─────────────────▶ M9 (R)
+```
+
+**First reviewable slice:** M1 + M2 (type model + manifest) — pure foundation, low risk,
+unblocks everything. Then split: M3+M4+M5 (the provenance/usability spine) vs M6
+(self-service) can proceed in parallel once M2 lands.
+
+---
+
+## Cross-repo summary
+
+| Repo | Milestones |
+|---|---|
+| workflow-service | M1, M2, M4, M6, M8 |
+| compute-node-aws-provisioner-v2 (`data-transfer`, `aslconverter`, `workflow-finalizer`, gateway) | M1, M2, M3, M4, M7, M9 |
+| account-service | M1 (model mirror), M6 (build-trigger API) |
+| processor-build-python-layer / new processor-build-r-layer | M2, M9 |
+| pennsieve-app (`Analysis/`) | M5, M6, M8, M10 |

--- a/docs/compute-node-layers-implementation.md
+++ b/docs/compute-node-layers-implementation.md
@@ -12,18 +12,18 @@ ordered by dependency; several are independently shippable.
 
 ---
 
-## Decisions to settle first (gate the build)
+## Decisions (settled)
 
-These shape multiple milestones; agree on them before M1.
+Agreed before build; these shape multiple milestones.
 
-| # | Decision | Options | Leaning |
-|---|---|---|---|
-| D1 | **Layer versioning** | overwrite-in-place vs immutable snapshot (`{name}@{hash}`) | snapshot for `python-env`/`r-env` (provenance refs them); overwrite OK for `data`, guarded by active-run check |
-| D2 | **Compatibility enforcement** | hard-fail vs warn at mount/select on python/R version mismatch | hard-fail at run submit; warn in selector |
-| D3 | **Consume-side wiring mechanism** | runtime entrypoint wrapper vs processor self-wiring (status quo) | keep self-wiring as the contract; add the wrapper as the centralized convenience (M3) |
-| D4 | **Provenance home** | run record only vs also Discover dataset provenance | run record for v1; Discover later |
-| D5 | **EFS import perf** | accept NFS imports vs stage layer → local at task start | accept for v1 (deps-on-base-image posture); revisit if cold-start hurts |
-| D6 | **Quota / GC** | per-node layer count/size cap + cleanup policy | define a cap before self-service (M6) |
+| # | Decision | **Settled** |
+|---|---|---|
+| D1 | **Layer versioning** | **Immutable snapshots (`{name}@{hash}`) for `python-env`/`r-env`** (a run references a stable env); **`data` layers overwrite in place**, guarded by an active-run check. |
+| D2 | **Compatibility enforcement** | **Hard-fail at run submit** on python/R version (or arch) mismatch; **warn earlier in the selector**. |
+| D3 | **Consume-side wiring** | **Keep consumer self-wiring from `LAYERS_DIR` as the contract; add an opt-in runtime entrypoint wrapper** that auto-appends `PYTHONPATH` from the manifest (never a clobbering env override). |
+| D4 | **Provenance home** | **Run record for v1; Discover dataset provenance later.** |
+| D5 | **EFS import perf** | **Accept NFS imports for v1** (base-image + thin-layer posture); measure cold-start, optimize (local staging) only if it hurts. |
+| D6 | **Quota / GC** | **No cap for v1** — ship self-service without quotas (admin/power-user-facing at first); add per-node limits + cleanup later if EFS/cost becomes a problem. |
 
 ---
 
@@ -136,12 +136,13 @@ shows type + contents.
   `persistent-layer` target) on the node; track build status.
 - pennsieve-app `ComputeNodeLayers.vue`: extend the create-layer form to
   `{name, requirements, pythonVersion}`; show a `BUILDING` state on the existing badge.
-- Quota/GC enforcement (D6).
+- No quota/GC for v1 (D6) — ships without per-node caps; revisit if EFS/cost grows.
 
 **Acceptance:** user submits a `requirements.txt` → layer builds on Fargate → shows READY →
-selectable; resolved lock captured (M2). Rejected on compliant nodes with a clear message.
+selectable; resolved lock captured (M2); rebuild creates a new snapshot (D1). Rejected on
+compliant nodes with a clear message.
 
-**Depends on:** M1, M2. **Decisions:** D1 (rebuild semantics), D6 (quota).
+**Depends on:** M1, M2. **Decisions:** D1 (snapshot on rebuild).
 
 ---
 

--- a/docs/compute-node-layers-plan.md
+++ b/docs/compute-node-layers-plan.md
@@ -1,0 +1,208 @@
+# Compute Node Layers — Typed Layers, Environments & Run Provenance
+
+## Problem
+
+Compute nodes already support **persistent layers** — read-only EFS directories that
+survive across executions and are mounted into runs (built by
+[`processor-build-python-layer`](https://github.com/Pennsieve/processor-build-python-layer)
+via the `persistent-layer` data-target; see workflow `4c23010f`). Today a layer is an
+opaque directory, but layers are used for two fundamentally different things:
+
+1. **Reference data** — e.g. make the human genome (GRCh38) available to a workflow.
+2. **Software environments** — a Python (`pip --target`) or R package set added to the
+   interpreter's path so processors/notebooks can `import`/`library()` without baking
+   everything into the base image.
+
+These are identical at the *storage* layer but diverge in how they are built, wired into
+a run, version-checked, and surfaced for provenance. Treating them as one untyped blob
+means: no automatic `PYTHONPATH`/`R_LIBS` wiring (every consumer hardcodes the path), no
+compatibility checks, and no way to record "what environment produced this result" — the
+provenance question that matters most for a scientific platform.
+
+## Goal
+
+- Add an explicit **layer type** (`data` | `python-env` | `r-env`, extensible) that drives
+  build, consume-side wiring, manifest schema, compatibility, and UX.
+- Make a layer's contents **usable without consumer-side hardcoding** — the platform wires
+  `PYTHONPATH` / `R_LIBS` / a data path based on the type.
+- Capture, per run (workflow **and** notebook), the **fully resolved environment** that
+  executed — base image + env layers + live package freeze — as an immutable provenance
+  record, and surface it (and reproduce from it) in the app.
+- Cleanly separate **software-environment provenance** from **reference-data provenance**.
+
+## Design Decisions
+
+- **Typed layers**: a `layerType` discriminator on the layer record and the
+  `persistent-layer` data-target. `data` is the default (back-compat for existing untyped
+  layers); `python-env` / `r-env` are explicit. Extensible (`conda-env`, `julia-env`…).
+- **Storage stays generic**: all types are a read-only EFS dir at
+  `/mnt/efs/{computeNodeId}/layers/{layerName}`; the type changes the *internal layout* and
+  *how it's consumed*, not where it lives.
+- **Consume-side wiring is the one real fork**: the ASL converter reads each requested
+  layer's `(type, version)` and injects the right env (`PYTHONPATH` / `R_LIBS_USER` /
+  `LAYER_<NAME>_DIR`). Today it injects only a generic `LAYERS_DIR`.
+- **Provenance = run-level freeze, not layer manifest**: the authoritative record is a
+  `pip freeze` / `renv` snapshot of the *live interpreter* at execution time, plus the
+  container image digest and the layer refs. Mechanism-agnostic — works whether the env
+  came from a layer, the base image, or a runtime install.
+- **Two provenance dimensions**: software environment (base image + env layers + freeze)
+  vs reference data (data layers). The layer type decides which dimension a layer feeds.
+- **Immutability**: env-layer provenance is only meaningful if a layer reference is stable.
+  Resolve the current overwrite-vs-snapshot ambiguity in favor of versioned snapshots for
+  env layers (see Open Questions).
+
+---
+
+## Layer Type Model
+
+| Type | Internal layout | Built by | Consumed by | Manifest / lockfile | Interpreter-coupled |
+|---|---|---|---|---|---|
+| **`data`** (default) | opaque file tree | any producer (download/stage, e.g. a genome) | mount + `LAYER_<NAME>_DIR` env var | description, size, source, domain version (e.g. `GRCh38`), optional checksum | No |
+| **`python-env`** | `lib/python{ver}/site-packages` (`pip install --target`) | `processor-build-python-layer` | prepend to `PYTHONPATH` (+ `bin/` → `PATH`) | `pip freeze`, `python_version`, `platform`/arch | Yes (wheel ABI) |
+| **`r-env`** | R library dir (`library/`) | `processor-build-r-layer` (analogous, `renv`/`pak`) | prepend to `R_LIBS_USER` / `.libPaths()` | `renv.lock`, `r_version`, `platform` | Yes (package ABI) |
+
+### What the type drives
+
+1. **Build** — a type-specific builder processor produces the right internal layout. Python
+   exists today; R is a direct analog; `data` is whatever stages the files.
+2. **Consume-side wiring** *(the crux)* — the converter branches on type:
+   - `data` → expose `LAYER_<NAME>_DIR=$LAYERS_DIR/{name}` (workflows reference reference-data by name).
+   - `python-env` → `PYTHONPATH = $LAYERS_DIR/{name}/lib/python{ver}/site-packages : …` (+ `bin/`→`PATH`), and `PYTHONPYCACHEPREFIX=/tmp/pycache` so the read-only, `--no-compile` tree caches bytecode per-task instead of recompiling every import.
+   - `r-env` → `R_LIBS_USER = $LAYERS_DIR/{name}/library : …`.
+   - Multiple env layers of the same language **stack** in list order.
+3. **Manifest schema** — discriminated by type (below).
+4. **Compatibility** — only env layers: the layer's `python_version`/`r_version` + platform
+   must match the consuming processor's interpreter, or the run fails at import. Validate at
+   mount/config and surface in the UI. Data layers have no ABI coupling.
+5. **UX** — a type badge; conditional rendering (env → language/version/packages; data →
+   size/source/domain version); compatibility hints for env layers only.
+6. **Provenance dimension** — env layers feed *software environment*; data layers feed
+   *reference data*.
+
+---
+
+## Data model changes
+
+### Layer record (`compute-node-layers`, workflow-service)
+Add:
+- `layerType: "data" | "python-env" | "r-env"` (default `data`)
+- `version` / `snapshotId` (immutable snapshot identifier; see Open Questions)
+- `manifestKey` — pointer to the layer's `manifest.json` on EFS/S3
+
+(account-service mirrors the schema for the healthchecker reconcile — see
+`internal/models/health.go` `LayerRecord` — and gains `layerType` there too.)
+
+### `persistent-layer` data-target params
+Today (`4c23010f`): `defaultParams.layerName`. Add:
+- `layerType` — declares the type at commit time; validated against the builder that produced it.
+
+### `manifest.json` (emitted by the builder, stored with the layer)
+Common: `{ layerType, layerName, createdAt, builder: {sourceUrl, tag}, sizeBytes, fileCount }`
+
+Type-specific:
+- `python-env`: `{ pythonVersion, platform, packages: [{name, version}], pipFreeze: "<raw>" }`
+- `r-env`: `{ rVersion, platform, renvLock: {...} }`
+- `data`: `{ source, domainVersion?, checksum? }`
+
+The manifest is the keystone: it lets the converter wire correctly (knows the
+`python{ver}` subpath), the UI render the catalog, and consumers reproduce.
+
+---
+
+## Run-level environment provenance
+
+Independent of *how* an environment was assembled, capture what actually ran:
+
+1. **At execution time** (processor entrypoint wrapper, uniform across processor + notebook):
+   - `pip freeze` / `installed.packages()` of the live interpreter (captures base image +
+     all env layers + any runtime install, already resolved).
+   - container image **digest** (`$ECS_CONTAINER_METADATA_URI_V4` → `Image` + digest).
+   - layer refs (the `Layers` list + each layer's `manifestKey`/version).
+   - processor source commit (`sourceUrl` + `tag`).
+   - → write `environment.json` (+ `environment.lock`) to `/mnt/efs/{cni}/{eri}/logs/{nodeId}/`.
+2. **At workflow end** — the finalizer collects per-node `environment.json` into a run-level
+   provenance bundle on the run record.
+3. **Notebooks** — the kernel drifts (mid-session `pip install`), so freeze at **session end**
+   (session-proxy/teardown) and embed the freeze into the saved `.ipynb` metadata so the
+   notebook is self-describing outside Pennsieve.
+
+### Endpoint
+`GET /compute/workflows/runs/{runId}/environment[?nodeId=]` — mirrors the existing per-node
+logs endpoint (`/runs/{runId}/logs?nodeId=`) the app already uses. Backed by the run
+provenance bundle.
+
+### Provenance split
+The run record exposes two sections, populated by layer type:
+- **Software environment** — base image digest + `python-env`/`r-env` layers + live freeze. *"What code ran."*
+- **Reference data** — `data` layers (e.g. genome build). *"What inputs/references it ran against."*
+
+### Reproduce
+Lock + image digest = rebuildable. A "re-run with this environment" action pins a new run to
+the captured image digest + layer versions (lock as the rebuild fallback).
+
+---
+
+## UX (pennsieve-app, `Analysis/`)
+
+Surfaces already exist; provenance attaches by extending them.
+
+- **`RunMonitor/RunDetail.vue`** *(MVP)* — clone the per-node **logs dialog**
+  (`openLogs` → logs endpoint) into an **Environment** dialog (`openEnvironment` → the new
+  environment endpoint). Per-node + a run-level summary. Shows base image, python/R version,
+  env layers (link to catalog), searchable package list, download lock, and "re-run with this
+  environment". Reference-data layers shown in a separate section.
+- **`ComputeNodes/ComputeNodeLayers.vue`** — the layers table exists (name/status/size/files);
+  add a **type badge** + manifest detail (env → language/version/packages via row-expand; data
+  → source/domain version), and "used by N workflows".
+- **`RunMonitor/LayerNameSelector.vue`** — filter/group by type; env preview + compatibility
+  hint (layer interpreter vs node base) when selecting.
+- **`JupyterSession/NotebookSession.vue`** — "snapshot environment" / "save as layer", a drift
+  indicator, and `.ipynb` freeze embedding.
+
+---
+
+## Cross-repo touchpoints
+
+| Concern | Repo |
+|---|---|
+| `layerType` + manifest on the layer record; active-run/layer reconcile | account-service (`internal/models/health.go`, healthchecker) + workflow-service (owner of `compute-node-layers`) |
+| `persistent-layer` data-target `layerType` param; `commit-layer`/`mount-layers`; converter env wiring (`PYTHONPATH`/`R_LIBS`/`LAYER_<NAME>_DIR`); run-env capture in `preDestroy`/finalizer; `manifest.json` handling | compute-node-aws-provisioner-v2 (`cmd/data-transfer`, `internal/aslconverter`, `cmd/workflow-finalizer`, gateway) |
+| `manifest.json` emission | processor-build-python-layer; new processor-build-r-layer |
+| Run-environment endpoint | gateway (`compute-gateway-v2`) / workflow-service |
+| Layer catalog, env dialog, selector, notebook snapshot | pennsieve-app (`src/components/Analysis/…`) |
+
+---
+
+## Phasing
+
+1. **Type model** — add `layerType` to the layer record + `persistent-layer` data-target;
+   default `data`. No behavior change yet.
+2. **Python env, end-to-end** — `manifest.json` from the build processor; converter wires
+   `PYTHONPATH`/`PYTHONPYCACHEPREFIX` from `python-env` layers; compatibility check.
+3. **Run-environment capture + endpoint** — entrypoint freeze + image digest + layer refs →
+   finalizer bundle → `GET /runs/{id}/environment`.
+4. **App MVP** — RunDetail Environment dialog (read provenance) + ComputeNodeLayers type badge.
+5. **Data layers** — `LAYER_<NAME>_DIR` wiring (trivial — just mount) + reference-data
+   provenance section.
+6. **R env** — `processor-build-r-layer` + `R_LIBS_USER` wiring + `renv.lock` manifest.
+7. **Reproduce + notebook snapshot/`.ipynb` embedding**; optional Discover provenance.
+
+---
+
+## Open Questions
+
+1. **Immutability/versioning** — `commit-layer` currently overwrites; the README claims
+   layers are immutable. For env layers (where run provenance references them) pick versioned
+   snapshots (`{name}@{hash}`) and have the converter pin consumers; data layers may tolerate
+   overwrite. Decide and make consistent.
+2. **Compatibility enforcement** — hard-fail vs warn-and-proceed on python/R version or arch
+   mismatch at mount/config.
+3. **EFS import latency** — env layers imported off NFS are slow; position as incremental deps
+   on a curated base image, and/or stage to local ephemeral storage at task start. Decide
+   whether to invest in local staging now.
+4. **Compliant mode** — builds can't reach PyPI/CRAN (no internet); needs a private mirror
+   (VPC endpoint / S3 index) or pre-built layers.
+5. **Provenance home** — run record only, or promote the environment + reference-data record
+   into the published dataset's provenance in Discover (highest reproducibility value).
+6. **Reproduce scope** — capture-only, or a first-class "rebuild environment from a run's lock"
+   action.

--- a/docs/compute-node-layers-plan.md
+++ b/docs/compute-node-layers-plan.md
@@ -55,6 +55,13 @@ provenance question that matters most for a scientific platform.
 - **Two provenance dimensions**: *software environment* (image digest + env layers + freeze)
   vs *inputs / reference data* (the primary dataset + data layers). The layer type decides
   which dimension a layer feeds — a genome is an input, not part of the software env.
+- **At most one env layer per processor** (one `python-env` and one `r-env`); **many `data`
+  layers** allowed. A `pip --target` tree is a *co-resolved* set; stacking two on
+  `PYTHONPATH` causes silent version shadowing / ABI breaks (positional precedence is not a
+  resolver). To combine env layers, rebuild one layer with the merged requirements so pip
+  co-resolves them — never compose at runtime. Data layers are independent file trees with
+  no resolution, so they compose freely. Enforced in `LayerNameSelector` (single-select for
+  env layers) + validated at run submit.
 - **Immutability**: env-layer provenance is only meaningful if a layer reference is stable.
   Resolve the current overwrite-vs-snapshot ambiguity in favor of versioned snapshots for
   env layers (see Open Questions).

--- a/docs/compute-node-layers-plan.md
+++ b/docs/compute-node-layers-plan.md
@@ -41,12 +41,20 @@ provenance question that matters most for a scientific platform.
 - **Consume-side wiring is the one real fork**: the ASL converter reads each requested
   layer's `(type, version)` and injects the right env (`PYTHONPATH` / `R_LIBS_USER` /
   `LAYER_<NAME>_DIR`). Today it injects only a generic `LAYERS_DIR`.
-- **Provenance = run-level freeze, not layer manifest**: the authoritative record is a
-  `pip freeze` / `renv` snapshot of the *live interpreter* at execution time, plus the
-  container image digest and the layer refs. Mechanism-agnostic — works whether the env
-  came from a layer, the base image, or a runtime install.
-- **Two provenance dimensions**: software environment (base image + env layers + freeze)
-  vs reference data (data layers). The layer type decides which dimension a layer feeds.
+- **The image digest is the universal environment record**: a non-interactive processor
+  is a Docker container, so its environment is fully defined by the **image digest +
+  mounted env-layer versions** — language-agnostic (Python, R, Julia, C++, bash), already
+  pinned, exact-reproducible by re-pull. A dependency **freeze is captured only for
+  interactive notebooks**, where the kernel drifts at runtime (`pip install` mid-session)
+  and the image alone under-describes what ran. General workflows need no language-specific
+  capture.
+- **Every layer carries a `manifest.json`, copied into the run** (not just referenced):
+  for env layers it's a **recipe** (lockfile + interpreter version); for data layers it's
+  an **identity + content fingerprint** (version, source, tree checksum). Copying it into
+  the run record makes provenance self-contained and survives layer deletion.
+- **Two provenance dimensions**: *software environment* (image digest + env layers + freeze)
+  vs *inputs / reference data* (the primary dataset + data layers). The layer type decides
+  which dimension a layer feeds — a genome is an input, not part of the software env.
 - **Immutability**: env-layer provenance is only meaningful if a layer reference is stable.
   Resolve the current overwrite-vs-snapshot ambiguity in favor of versioned snapshots for
   env layers (see Open Questions).
@@ -102,29 +110,45 @@ Common: `{ layerType, layerName, createdAt, builder: {sourceUrl, tag}, sizeBytes
 Type-specific:
 - `python-env`: `{ pythonVersion, platform, packages: [{name, version}], pipFreeze: "<raw>" }`
 - `r-env`: `{ rVersion, platform, renvLock: {...} }`
-- `data`: `{ source, domainVersion?, checksum? }`
+- `data`: `{ version, source, treeChecksum, files?: [{path, sizeBytes, sha256}] }` — an
+  *identity + content fingerprint*, not a recipe. **Bound the inline `files` list**: always
+  include `treeChecksum` + counts; include per-file entries only when `fileCount` is small
+  (a genome has few large files; a million-file reference DB does not) — otherwise store the
+  full file manifest as a separate artifact referenced by hash.
 
-The manifest is the keystone: it lets the converter wire correctly (knows the
-`python{ver}` subpath), the UI render the catalog, and consumers reproduce.
+The manifest is the keystone: it lets the converter wire env layers correctly (knows the
+`python{ver}` subpath), the UI render the catalog, consumers reproduce, and — copied into
+each run — provenance survive layer deletion. `commit-layer` is the natural place to
+generate it (it already computes `sizeBytes`/`fileCount`; add `treeChecksum`).
 
 ---
 
 ## Run-level environment provenance
 
-Independent of *how* an environment was assembled, capture what actually ran:
+The software environment is **fully defined by the container image digest + mounted
+env-layer versions** — language-agnostic and already pinned. So capture is cheap and
+*conditional on node type*; a dependency freeze is only needed where the environment is
+mutable beyond the image.
 
-1. **At execution time** (processor entrypoint wrapper, uniform across processor + notebook):
-   - `pip freeze` / `installed.packages()` of the live interpreter (captures base image +
-     all env layers + any runtime install, already resolved).
-   - container image **digest** (`$ECS_CONTAINER_METADATA_URI_V4` → `Image` + digest).
-   - layer refs (the `Layers` list + each layer's `manifestKey`/version).
-   - processor source commit (`sourceUrl` + `tag`).
-   - → write `environment.json` (+ `environment.lock`) to `/mnt/efs/{cni}/{eri}/logs/{nodeId}/`.
+| Node | Captured | Freeze? |
+|---|---|---|
+| Non-interactive processor (any language) | image digest + env-layer versions (+ data-layer identities) | **No** — the image *is* the environment; don't assume a Python/R interpreter exists |
+| Interactive notebook | image digest + env-layer versions + **live `pip freeze`/`renv`** | **Yes** — the kernel drifts at runtime |
+
+A non-interactive processor that runtime-installs deps is an **anti-pattern** (it escapes
+the image); flag rather than chase it with a freeze — processors should bake deps into the
+image.
+
+**Capture mechanics:**
+1. **At execution time** — record the image digest (`$ECS_CONTAINER_METADATA_URI_V4` →
+   `Image` + digest), the mounted layer refs, **a copy of each mounted layer's
+   `manifest.json`** (recipe for env layers, identity+fingerprint for data layers), the
+   processor source commit (`sourceUrl` + `tag`), and — interactive only — the live freeze.
+   Write `environment.json` to `/mnt/efs/{cni}/{eri}/logs/{nodeId}/`.
 2. **At workflow end** — the finalizer collects per-node `environment.json` into a run-level
    provenance bundle on the run record.
-3. **Notebooks** — the kernel drifts (mid-session `pip install`), so freeze at **session end**
-   (session-proxy/teardown) and embed the freeze into the saved `.ipynb` metadata so the
-   notebook is self-describing outside Pennsieve.
+3. **Notebooks** — freeze at **session end** (session-proxy/teardown) and embed it into the
+   saved `.ipynb` metadata so the notebook is self-describing outside Pennsieve.
 
 ### Endpoint
 `GET /compute/workflows/runs/{runId}/environment[?nodeId=]` — mirrors the existing per-node
@@ -132,13 +156,28 @@ logs endpoint (`/runs/{runId}/logs?nodeId=`) the app already uses. Backed by the
 provenance bundle.
 
 ### Provenance split
-The run record exposes two sections, populated by layer type:
-- **Software environment** — base image digest + `python-env`/`r-env` layers + live freeze. *"What code ran."*
-- **Reference data** — `data` layers (e.g. genome build). *"What inputs/references it ran against."*
+The run record exposes two dimensions; **the layer type routes each layer to one**:
+- **Software environment** — image digest + `python-env`/`r-env` layers (+ interactive freeze). *"What code ran."*
+- **Inputs / reference data** — the primary dataset (data-source, already tracked) + `data` layers (e.g. genome build), recorded by **identity** (version + source + tree checksum), not a recipe. *"What it ran against."*
+
+### Provenance durability & layer lifecycle
+Because each mounted layer's manifest is **copied into the run** (not just referenced),
+deleting a layer never destroys a run's provenance — only its instant re-mount:
+
+| | Manifest payload | Reproduce | If layer deleted |
+|---|---|---|---|
+| env layer | recipe (lockfile + version) | rebuild from lockfile | re-derive (best-effort; may drift if upstream packages vanish) |
+| data layer | identity (version + source + tree checksum) | re-reference the bytes | re-fetch from `source`, verify by checksum |
+
+So layer DELETE should either warn that referenced runs lose exact re-mount (reproduce →
+rebuild/re-fetch), or **archive the layer to S3** so exact bytes stay recoverable. Hash-pin
+hard (`--require-hashes` / `uv.lock` / `renv.lock`) + image digest gets most of the way to
+exact without keeping files. *(Note current gap: `commit-layer` overwrites and gateway
+`DELETE /layers/{name}` removes metadata with no run-reference guard and no copy-into-run.)*
 
 ### Reproduce
-Lock + image digest = rebuildable. A "re-run with this environment" action pins a new run to
-the captured image digest + layer versions (lock as the rebuild fallback).
+Image digest + the copied manifests = rebuildable. A "re-run with this environment" action
+pins a new run to the captured image digest + layer versions (lockfile rebuild / data re-fetch as fallback).
 
 ---
 

--- a/docs/compute-node-layers-plan.md
+++ b/docs/compute-node-layers-plan.md
@@ -188,6 +188,54 @@ pins a new run to the captured image digest + layer versions (lockfile rebuild /
 
 ---
 
+## Self-service env layers (`requirements.txt` → build)
+
+Today layer builds are **admin-driven**: each layer is a hand-authored workflow whose package
+list is baked into terraform (`4c23010f`'s `defaultParams.REQUIREMENTS`) and triggered via
+`POST /runs`. The builder (`processor-build-python-layer`) is already *generic* —
+`REQUIREMENTS` is a parameter ("one image, many layers") — so flipping this to **self-service**
+is mostly a user-facing trigger, not new infrastructure.
+
+### Flow
+```
+User (app, on their compute node): layer name + requirements.txt + python version
+  → account-service/workflow-service launches the build workflow on the node:
+        trigger → python-layer-builder (REQUIREMENTS=<user list>, PYTHON_VERSION=<v>)
+                → persistent-layer data-target (layerName=<user name>)
+  → (Fargate, ~5–10 min)  layer committed → ComputeNodeLayers shows READY
+  → user selects it for a workflow/notebook (LayerNameSelector)
+```
+
+### Reused vs. new
+- **Reused**: the generic builder, the build-workflow shape, the layer catalog +
+  create-layer form (`ComputeNodeLayers.vue` already takes `{name, description}`), the
+  status badge (a `BUILDING` state fits the existing READY/pending badges).
+- **New**: a build-trigger API that parameterizes the workflow from `requirements.txt` +
+  python version and runs it on the user's node; build status tracking; manifest capture.
+
+### Per-deployment-mode availability
+Env-layer builds need PyPI (internet), so they're a basic/secure feature; compliant defines
+its environment in the image instead. (Compliant has no internet — and no interactive nodes —
+so there's nothing to mirror; the earlier "private PyPI mirror" question drops.)
+
+| | basic / secure | compliant |
+|---|---|---|
+| **env layer** (pip build) | self-service | bake into the image |
+| **data layer** (e.g. genome) | yes | yes — staged from S3 via the gateway endpoint (mount needs no internet) |
+| **interactive notebook** | yes | no (already the case) |
+
+### Decisions
+- **Keep curated *and* self-service** — admin-curated shared stacks (the `quick-plot-stack`
+  model) alongside user-built layers; don't drop curation.
+- **Python-version compatibility** — the form must pick a version matching an available base
+  image, or you build a `3.12` layer a `3.11` processor can't use (the manifest/compat concern).
+- **Capture the resolved lock** — persist `pip freeze`, not just the input `requirements.txt`;
+  show the user what actually resolved.
+- **Versioning** — overwrite vs snapshot on rebuild, guarded by the active-run check.
+- **Quota/GC** — builds cost Fargate, layers cost EFS; per-node quota + cleanup.
+
+---
+
 ## UX (pennsieve-app, `Analysis/`)
 
 Surfaces already exist; provenance attaches by extending them.
@@ -228,10 +276,12 @@ Surfaces already exist; provenance attaches by extending them.
 3. **Run-environment capture + endpoint** — entrypoint freeze + image digest + layer refs →
    finalizer bundle → `GET /runs/{id}/environment`.
 4. **App MVP** — RunDetail Environment dialog (read provenance) + ComputeNodeLayers type badge.
-5. **Data layers** — `LAYER_<NAME>_DIR` wiring (trivial — just mount) + reference-data
+5. **Self-service env layers** — `requirements.txt` → build-trigger API + ComputeNodeLayers
+   create-from-requirements form + build status (basic/secure).
+6. **Data layers** — `LAYER_<NAME>_DIR` wiring (trivial — just mount) + reference-data
    provenance section.
-6. **R env** — `processor-build-r-layer` + `R_LIBS_USER` wiring + `renv.lock` manifest.
-7. **Reproduce + notebook snapshot/`.ipynb` embedding**; optional Discover provenance.
+7. **R env** — `processor-build-r-layer` + `R_LIBS_USER` wiring + `renv.lock` manifest.
+8. **Reproduce + notebook snapshot/`.ipynb` embedding**; optional Discover provenance.
 
 ---
 
@@ -246,8 +296,9 @@ Surfaces already exist; provenance attaches by extending them.
 3. **EFS import latency** — env layers imported off NFS are slow; position as incremental deps
    on a curated base image, and/or stage to local ephemeral storage at task start. Decide
    whether to invest in local staging now.
-4. **Compliant mode** — builds can't reach PyPI/CRAN (no internet); needs a private mirror
-   (VPC endpoint / S3 index) or pre-built layers.
+4. **Compliant mode** — *resolved*: env-layer builds need PyPI/CRAN (internet), so they're
+   basic/secure only; compliant defines its environment in the image (no mirror needed). Data
+   layers still work in compliant (S3-staged via the gateway endpoint).
 5. **Provenance home** — run record only, or promote the environment + reference-data record
    into the published dataset's provenance in Discover (highest reproducibility value).
 6. **Reproduce scope** — capture-only, or a first-class "rebuild environment from a run's lock"

--- a/docs/compute-node-layers-plan.md
+++ b/docs/compute-node-layers-plan.md
@@ -38,9 +38,17 @@ provenance question that matters most for a scientific platform.
 - **Storage stays generic**: all types are a read-only EFS dir at
   `/mnt/efs/{computeNodeId}/layers/{layerName}`; the type changes the *internal layout* and
   *how it's consumed*, not where it lives.
-- **Consume-side wiring is the one real fork**: the ASL converter reads each requested
-  layer's `(type, version)` and injects the right env (`PYTHONPATH` / `R_LIBS_USER` /
-  `LAYER_<NAME>_DIR`). Today it injects only a generic `LAYERS_DIR`.
+- **Consume-side wiring must APPEND, not clobber**: the converter injects a generic
+  `LAYERS_DIR` today, and the **current contract is consumer self-wiring** — the processor
+  reads `LAYERS_DIR` and does `sys.path.insert(...)` itself (e.g. `pennsieve-quick-plot`).
+  Centralizing this (auto-set `PYTHONPATH`/`R_LIBS_USER`/`LAYER_<NAME>_DIR`) is desirable but
+  **cannot be done via an ECS env override**: overrides *replace* the image's value (no
+  `${PYTHONPATH}` shell-expansion), so they'd drop an image's own `PYTHONPATH` — e.g.
+  `quick-plot`'s `ENV PYTHONPATH=/app`, breaking its imports. (A clobbering override was
+  prototyped and rejected — see provisioner #34.) Safe auto-wiring needs a **runtime
+  entrypoint wrapper** that appends, plus the layer's **python version** (from the manifest)
+  to know the `lib/python{ver}/site-packages` subpath — so it's future work, not a converter
+  one-liner. Until then, consumer self-wiring from `LAYERS_DIR` stands.
 - **The image digest is the universal environment record**: a non-interactive processor
   is a Docker container, so its environment is fully defined by the **image digest +
   mounted env-layer versions** — language-agnostic (Python, R, Julia, C++, bash), already
@@ -271,8 +279,11 @@ Surfaces already exist; provenance attaches by extending them.
 
 1. **Type model** — add `layerType` to the layer record + `persistent-layer` data-target;
    default `data`. No behavior change yet.
-2. **Python env, end-to-end** — `manifest.json` from the build processor; converter wires
-   `PYTHONPATH`/`PYTHONPYCACHEPREFIX` from `python-env` layers; compatibility check.
+2. **Python env, end-to-end** — `manifest.json` from the build processor (incl. `pythonVersion`);
+   safe auto-wiring via a **runtime entrypoint wrapper** that *appends* the layer's
+   `lib/python{ver}/site-packages` to `PYTHONPATH` (+ `PYTHONPYCACHEPREFIX=/tmp/pycache`) —
+   not a clobbering ECS env override (see Consume-side wiring); compatibility check. Until
+   this lands, consumers self-wire from `LAYERS_DIR`.
 3. **Run-environment capture + endpoint** — entrypoint freeze + image digest + layer refs →
    finalizer bundle → `GET /runs/{id}/environment`.
 4. **App MVP** — RunDetail Environment dialog (read provenance) + ComputeNodeLayers type badge.


### PR DESCRIPTION
Design note (no code) capturing the plan we worked through for compute-node layers.

## Covers
- **Typed layers** — a `layerType` discriminator (`data` | `python-env` | `r-env`, extensible) and what the type drives: build, **consume-side wiring** (the one real fork — `PYTHONPATH` / `R_LIBS_USER` / `LAYER_<NAME>_DIR`), manifest schemas, compatibility, and UX.
- **Run-level environment provenance** — capture the *live* `pip freeze`/`renv` + container image digest + layer refs per processor/notebook, collected by the finalizer, exposed via `GET /runs/{id}/environment` (mirrors the existing per-node logs endpoint).
- **Two provenance dimensions** — software environment (base image + env layers + freeze) vs reference data (data layers, e.g. a genome), split by layer type.
- **UX attachment points** in `pennsieve-app` `Analysis/` (RunDetail env dialog, ComputeNodeLayers catalog, LayerNameSelector, NotebookSession) — extending surfaces that already exist.
- **Cross-repo touchpoints**, **phasing**, and **open questions** (immutability/versioning, EFS import latency, compliant-mode mirror, Discover provenance, reproduce scope).

Grounds on the current implementation: `processor-build-python-layer` (`pip --target` → `lib/python{ver}/site-packages`), the `persistent-layer` data-target (workflow `4c23010f`), `data-transfer` `commit-layer`/`mount-layers`, the converter's `LAYERS_DIR` injection, and the existing app components.

Intended as a reviewable artifact before any implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)