### PR TITLE
feat(layers): mirror layer identity fields in LayerRecord (M1/M2)

### DIFF
--- a/internal/models/health.go
+++ b/internal/models/health.go
@@ -38,6 +38,11 @@ type HealthCheckIssue struct {
 }
 
 // LayerRecord mirrors the workflow-service compute-node-layers DynamoDB schema.
+// It must stay in sync with that schema: the healthchecker's layer reconcile does a
+// read-modify-write of the whole record (MarshalMap), so any field missing here would
+// be dropped when reconcile corrects size/fileCount. The identity fields below
+// (layerType/snapshotId/treeChecksum/pythonVersion) are set by commit-layer; mirror
+// them so reconcile preserves them.
 type LayerRecord struct {
 	ComputeNodeId string `dynamodbav:"computeNodeId"`
 	LayerName     string `dynamodbav:"layerName"`
@@ -48,6 +53,10 @@ type LayerRecord struct {
 	CreatedAt     string `dynamodbav:"createdAt"`
 	CreatedBy     string `dynamodbav:"createdBy"`
 	LastAccessed  string `dynamodbav:"lastAccessed,omitempty"`
+	LayerType     string `dynamodbav:"layerType,omitempty"`
+	SnapshotId    string `dynamodbav:"snapshotId,omitempty"`
+	TreeChecksum  string `dynamodbav:"treeChecksum,omitempty"`
+	PythonVersion string `dynamodbav:"pythonVersion,omitempty"`
 }
 
 // DynamoDBHealthCheckLog is the DynamoDB record for a health check log entry.


### PR DESCRIPTION
Final foundation slice (M1/M2). Mirrors the layer identity fields onto account-service's `LayerRecord` so the healthchecker reconcile doesn't drop them.

## What
`LayerRecord` (the mirror of workflow-service's `compute-node-layers` schema) gains `layerType`, `snapshotId`, `treeChecksum`, `pythonVersion` (all `omitempty`).

## Why it's required (not cosmetic)
The healthchecker's layer reconcile reads a record, corrects `sizeBytes`/`fileCount`, and writes the **whole** record back (`MarshalMap` → PutItem). Any field absent from this struct would be **wiped** on the next reconcile — so without mirroring, reconcile would erase the `layerType`/`snapshotId` that `commit-layer` set. Adding them means reconcile preserves the identity.

## Completes the foundation
M1/M2 now span end-to-end:
1. [processor-build-python-layer #2](https://github.com/Pennsieve/processor-build-python-layer/pull/2) — emits `manifest.json`
2. [provisioner #36](https://github.com/Pennsieve/compute-node-aws-provisioner-v2/pull/36) — `commit-layer` derives `layerType` + content-addressed `snapshotId` + `treeChecksum`
3. [workflow-service #50](https://github.com/Pennsieve/workflow-service/pull/50) — stores them on the record + list API
4. **this** — account-service mirror (reconcile-safe)

Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)