### PR TITLE
fix(iam): grant eventbridge handler GetItem on the accounts table

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -541,6 +541,10 @@ data "aws_iam_policy_document" "eventbridge_handler_iam_policy_document" {
     resources = [
       aws_dynamodb_table.compute_resource_nodes_table.arn,
       "${aws_dynamodb_table.compute_resource_nodes_table.arn}/*",
+      # The interactive phase-2 auto-trigger reads the accounts table to resolve
+      # the per-account compute role before re-provisioning (reprovision_phase2.go).
+      aws_dynamodb_table.accounts_table.arn,
+      "${aws_dynamodb_table.accounts_table.arn}/*",
       aws_dynamodb_table.storage_nodes_table.arn,
       "${aws_dynamodb_table.storage_nodes_table.arn}/*",
       aws_dynamodb_table.storage_node_workspace_table.arn,


### PR DESCRIPTION
## What

Grant the EventBridge handler lambda role `dynamodb:GetItem` (and the other DynamoDB actions already on the statement) on the **accounts** table.

## Why

Creating an interactive (Jupyter) compute node is meant to deploy in a single user action: the provisioner runs phase 1 (zone + cert + ALB), account-service delegates the per-account zone, and then the EventBridge handler auto-triggers a phase-2 re-provision (`triggerInteractivePhase2`) that completes ACM validation + the shared ALB's HTTPS listener — no operator action required.

That auto-trigger reads the accounts table to resolve the per-account compute role before launching the re-provision ([`reprovision_phase2.go`](internal/handler/compute/reprovision_phase2.go)). But the EventBridge handler's IAM policy only granted DynamoDB access to the **nodes** and **storage** tables, not **accounts**. So phase 2 failed best-effort with:

```
phase2: could not load account <uuid>: AccessDeniedException:
  prod-account-service-eventbridge-lambda-role-use1 is not authorized to perform:
  dynamodb:GetItem on prod-compute-resource-accounts-table-use1
```

and the HTTPS listener was never created — forcing operators to manually redeploy the node to complete interactive HTTPS. Observed in prod (node `ad4fe162…`, account `537996532276`).

## Fix

Add the accounts table ARN (+ index wildcard) to the `EventBridgeHandlerDynamoDBPermissions` statement resources in `terraform/iam.tf`.

## Note

This restores the intended one-deploy auto-completion for **future** nodes. A node already stuck in phase 1 can still be completed by a manual redeploy (the provisioner's own delegation detection creates the listener independently of this path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
