### PR TITLE
fix(interactive): set TASK_DEF_ARN on eventbridge handler for phase-2 auto-trigger

### DIFF
--- a/internal/handler/compute/reprovision_phase2.go
+++ b/internal/handler/compute/reprovision_phase2.go
@@ -44,8 +44,8 @@ func triggerInteractivePhase2(ctx context.Context, cfg aws.Config, nodeStore sto
 	cluster := os.Getenv("CLUSTER_ARN")
 	taskDefContainerName := os.Getenv("TASK_DEF_CONTAINER_NAME")
 	securityGroup := os.Getenv("SECURITY_GROUP")
-	if cluster == "" || taskDefContainerName == "" || securityGroup == "" || os.Getenv("SUBNET_IDS") == "" {
-		log.Printf("phase2: launch env not configured on this lambda (CLUSTER_ARN/SUBNET_IDS/SECURITY_GROUP/TASK_DEF_CONTAINER_NAME); skipping auto-trigger for node %s", computeNodeID)
+	if cluster == "" || taskDefContainerName == "" || securityGroup == "" || os.Getenv("SUBNET_IDS") == "" || os.Getenv("TASK_DEF_ARN") == "" {
+		log.Printf("phase2: launch env not configured on this lambda (CLUSTER_ARN/SUBNET_IDS/SECURITY_GROUP/TASK_DEF_CONTAINER_NAME/TASK_DEF_ARN); skipping auto-trigger for node %s", computeNodeID)
 		return
 	}
 	subnetIDs := strings.Split(os.Getenv("SUBNET_IDS"), ",")

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -98,6 +98,7 @@ resource "aws_lambda_function" "eventbridge_handler_lambda" {
       # (UPDATE re-provision) after it creates the NS delegation. Mirrors the
       # service lambda. Empty/unset → the handler logs + skips (graceful).
       ACCOUNTS_TABLE          = aws_dynamodb_table.accounts_table.name
+      TASK_DEF_ARN            = aws_ecs_task_definition.provisioner_ecs_task_definition.arn
       CLUSTER_ARN             = data.terraform_remote_state.fargate.outputs.ecs_cluster_arn
       SUBNET_IDS              = join(",", data.terraform_remote_state.vpc.outputs.private_subnet_ids)
       SECURITY_GROUP          = data.terraform_remote_state.platform_infrastructure.outputs.rehydration_fargate_security_group_id


### PR DESCRIPTION
## What

Set `TASK_DEF_ARN` on the EventBridge handler lambda so the interactive phase-2 auto-trigger can actually launch its re-provision task.

## Why

This is the **next** gap exposed after [#77](https://github.com/Pennsieve/account-service/pull/77) (which fixed the accounts-table read). On a fresh interactive node deploy, the auto phase-2 chain now gets all the way to launching the re-provision task, then fails:

```
Ensured interactive NS delegation for 376308453966.compute.pennsieve.io (newlyCreated=true)
phase2: task def for node 599f80a6…: TASK_DEF_ARN environment variable not set
```

`triggerInteractivePhase2` → `createDynamicTaskDefinition` reads `TASK_DEF_ARN` to clone the base provisioner task definition. The EventBridge handler lambda set `CLUSTER_ARN` / `SUBNET_IDS` / `SECURITY_GROUP` / `TASK_DEF_CONTAINER_NAME` (its env block even comments "Mirrors the service lambda") but omitted `TASK_DEF_ARN` — which the service lambda does set. So the HTTPS listener was never created automatically and an operator had to redeploy the node manually.

## Changes

- `terraform/lambda.tf`: add `TASK_DEF_ARN = aws_ecs_task_definition.provisioner_ecs_task_definition.arn` to the eventbridge handler env (now truly mirrors the service lambda).
- `internal/handler/compute/reprovision_phase2.go`: include `TASK_DEF_ARN` in the launch-env guard, so a missing value logs + skips gracefully (the intended best-effort behavior) instead of erroring partway through.

## Validation

Traced end-to-end on a fresh node (`376308453966`): role re-sync cleared the ELB 403, provisioner v1.7.6 created the `.io` zone/cert/ALB, account-service delegated the zone, and the phase-2 trigger fired and passed the accounts-table read — failing only here. With this, the chain should complete the HTTPS listener with no manual redeploy.

## Testing

`go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
