### PR TITLE
feat(compute): flag outdated compute nodes on GET /compute-nodes

### DIFF
--- a/cmd/health-checker/main.go
+++ b/cmd/health-checker/main.go
@@ -8,6 +8,9 @@ import (
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/pennsieve/account-service/internal/dockerhub"
 	"github.com/pennsieve/account-service/internal/handler/healthchecker"
 	"github.com/pennsieve/account-service/internal/store_dynamodb"
 )
@@ -29,11 +32,19 @@ func handler(ctx context.Context) error {
 
 	ddbClient := dynamodb.NewFromConfig(cfg)
 
+	tagRefresher := dockerhub.NewResolver(
+		secretsmanager.NewFromConfig(cfg),
+		ssm.NewFromConfig(cfg),
+		os.Getenv("DOCKER_HUB_CREDENTIALS_SECRET_ARN"),
+		os.Getenv("ENV"),
+	)
+
 	h := &healthchecker.Handler{
 		NodeStore:      store_dynamodb.NewNodeDatabaseStore(ddbClient, nodesTable),
 		HealthLogStore: store_dynamodb.NewHealthCheckLogDatabaseStore(ddbClient, healthLogTable),
 		DDBClient:      ddbClient,
 		LayersTable:    layersTable,
+		TagRefresher:   tagRefresher,
 		Config: healthchecker.Config{
 			Region: region,
 			AWSCfg: cfg,

--- a/internal/dockerhub/dockerhub.go
+++ b/internal/dockerhub/dockerhub.go
@@ -1,0 +1,414 @@
+// Package dockerhub resolves the latest released version tag for the private
+// provisioner images on Docker Hub. The GET /compute-nodes endpoint uses it to
+// tell the frontend whether a node's pinned provisioner tag is behind the
+// newest real vX.Y.Z release.
+//
+// Docker Hub repos are private, so we authenticate with the same credentials the
+// ECS provisioner uses (a Secrets Manager secret holding {"username","password"})
+// via the registry v2 token flow. Results are cached in-process so the
+// frequently-called list endpoint stays fast and we don't hit Docker Hub rate
+// limits; on a lookup error we serve the last good (stale) value rather than
+// failing the caller.
+package dockerhub
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+)
+
+const (
+	authURL     = "https://auth.docker.io/token"
+	registryURL = "https://registry-1.docker.io"
+	// defaultTTL bounds how long a warm container reuses a tag before re-reading
+	// the shared SSM cache. The scheduled refresher (health-checker) is the real
+	// freshness driver; this just limits per-container SSM reads.
+	defaultTTL = 5 * time.Minute
+
+	// whitelistParam enumerates the provisioner images to track (shared with the
+	// POST handler's image whitelist).
+	whitelistParam = "/%s/account-service/provisioner-images-whitelist"
+	// latestTagParam is the shared cache the refresher writes and GET reads.
+	latestTagParam = "/%s/account-service/provisioner-latest-tag/%s"
+)
+
+// semverTag matches a real release tag: an optional leading "v" followed by
+// MAJOR.MINOR.PATCH. Tags like "latest" or "v1.2" are intentionally excluded.
+var semverTag = regexp.MustCompile(`^v?(\d+)\.(\d+)\.(\d+)$`)
+
+// SecretsAPI is the subset of the Secrets Manager client used here.
+type SecretsAPI interface {
+	GetSecretValue(ctx context.Context, in *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error)
+}
+
+// SSMAPI is the subset of the SSM client used here. GetParameter backs the
+// shared read cache; PutParameter is the refresher's write.
+type SSMAPI interface {
+	GetParameter(ctx context.Context, in *ssm.GetParameterInput, optFns ...func(*ssm.Options)) (*ssm.GetParameterOutput, error)
+	PutParameter(ctx context.Context, in *ssm.PutParameterInput, optFns ...func(*ssm.Options)) (*ssm.PutParameterOutput, error)
+}
+
+// HTTPClient is the subset of *http.Client used here (for testing).
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type cacheEntry struct {
+	latest    string
+	fetchedAt time.Time
+}
+
+// Resolver resolves the latest semver tag per image across three tiers: an
+// in-process map (L1), a shared SSM parameter (L2, written by the scheduled
+// refresher), and a direct Docker Hub lookup (fallback / refresher source).
+type Resolver struct {
+	sm        SecretsAPI
+	ssm       SSMAPI
+	http      HTTPClient
+	secretArn string
+	env       string
+	ttl       time.Duration
+	now       func() time.Time
+
+	mu    sync.Mutex
+	cache map[string]cacheEntry
+	creds *dockerCreds // resolved lazily, then reused
+}
+
+type dockerCreds struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+// NewResolver builds a resolver. secretArn is the Secrets Manager secret holding
+// the Docker Hub username/password; env is the deployment environment used to
+// build SSM parameter paths.
+func NewResolver(sm SecretsAPI, ssmClient SSMAPI, secretArn, env string) *Resolver {
+	if env == "" {
+		env = "dev"
+	}
+	return &Resolver{
+		sm:        sm,
+		ssm:       ssmClient,
+		http:      &http.Client{Timeout: 10 * time.Second},
+		secretArn: secretArn,
+		env:       env,
+		ttl:       defaultTTL,
+		now:       time.Now,
+		cache:     make(map[string]cacheEntry),
+	}
+}
+
+// LatestVersion returns the highest real vX.Y.Z tag for image (e.g.
+// "pennsieve/compute-node-aws-provisioner-v2") on the read path used by GET
+// /compute-nodes. It checks the in-process cache, then the shared SSM cache, and
+// only as a last resort queries Docker Hub directly (self-healing if the
+// scheduled refresher hasn't populated SSM yet). An empty string means
+// "unknown" — callers should treat that as "can't determine" and not flag.
+func (r *Resolver) LatestVersion(ctx context.Context, image string) string {
+	// L1: in-process cache.
+	r.mu.Lock()
+	entry, ok := r.cache[image]
+	fresh := ok && r.now().Sub(entry.fetchedAt) < r.ttl
+	r.mu.Unlock()
+	if fresh {
+		return entry.latest
+	}
+
+	// L2: shared SSM cache.
+	if latest, ok := r.ssmGet(ctx, image); ok {
+		r.store(image, latest)
+		return latest
+	}
+
+	// Fallback: query Docker Hub directly and best-effort seed the shared cache.
+	latest, err := r.fetchLatest(ctx, image)
+	if err != nil {
+		return entry.latest // serve stale (possibly "") rather than failing the caller
+	}
+	r.store(image, latest)
+	r.ssmPut(ctx, image, latest)
+	return latest
+}
+
+// Refresh queries Docker Hub for the latest tag and writes it to the shared SSM
+// cache, updating the in-process cache too. This is the scheduled refresher's
+// entry point (called from the health-checker). Returns the resolved tag.
+func (r *Resolver) Refresh(ctx context.Context, image string) (string, error) {
+	latest, err := r.fetchLatest(ctx, image)
+	if err != nil {
+		return "", err
+	}
+	if err := r.ssmPut(ctx, image, latest); err != nil {
+		return latest, err
+	}
+	r.store(image, latest)
+	return latest, nil
+}
+
+// RefreshAll refreshes every image in the provisioner whitelist. It refreshes
+// all images even if some fail, returning the first error encountered.
+func (r *Resolver) RefreshAll(ctx context.Context) error {
+	images, err := r.whitelistImages(ctx)
+	if err != nil {
+		return err
+	}
+	var firstErr error
+	for _, image := range images {
+		if _, err := r.Refresh(ctx, image); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (r *Resolver) store(image, latest string) {
+	r.mu.Lock()
+	r.cache[image] = cacheEntry{latest: latest, fetchedAt: r.now()}
+	r.mu.Unlock()
+}
+
+// ssmGet reads the cached latest tag for image. ok is false on a missing
+// parameter, any error, or a value that isn't a real vX.Y.Z tag — the last case
+// covers the Terraform-seeded "dummy" placeholder before the first refresh, so
+// callers fall through to Docker Hub and self-heal rather than surfacing junk.
+func (r *Resolver) ssmGet(ctx context.Context, image string) (string, bool) {
+	out, err := r.ssm.GetParameter(ctx, &ssm.GetParameterInput{
+		Name: aws.String(fmt.Sprintf(latestTagParam, r.env, image)),
+	})
+	if err != nil || out.Parameter == nil || out.Parameter.Value == nil {
+		return "", false
+	}
+	value := *out.Parameter.Value
+	if !semverTag.MatchString(value) {
+		return "", false
+	}
+	return value, true
+}
+
+func (r *Resolver) ssmPut(ctx context.Context, image, latest string) error {
+	_, err := r.ssm.PutParameter(ctx, &ssm.PutParameterInput{
+		Name:      aws.String(fmt.Sprintf(latestTagParam, r.env, image)),
+		Value:     aws.String(latest),
+		Type:      ssmtypes.ParameterTypeString,
+		Overwrite: aws.Bool(true),
+	})
+	if err != nil {
+		return fmt.Errorf("write latest-tag cache for %s: %w", image, err)
+	}
+	return nil
+}
+
+func (r *Resolver) whitelistImages(ctx context.Context) ([]string, error) {
+	out, err := r.ssm.GetParameter(ctx, &ssm.GetParameterInput{
+		Name: aws.String(fmt.Sprintf(whitelistParam, r.env)),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("read provisioner whitelist: %w", err)
+	}
+	if out.Parameter == nil || out.Parameter.Value == nil {
+		return nil, fmt.Errorf("provisioner whitelist parameter is empty")
+	}
+	var images []string
+	for _, img := range strings.Split(*out.Parameter.Value, ",") {
+		if trimmed := strings.TrimSpace(img); trimmed != "" {
+			images = append(images, trimmed)
+		}
+	}
+	return images, nil
+}
+
+func (r *Resolver) fetchLatest(ctx context.Context, image string) (string, error) {
+	creds, err := r.getCreds(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	token, err := r.getToken(ctx, image, creds)
+	if err != nil {
+		return "", err
+	}
+
+	tags, err := r.listTags(ctx, image, token)
+	if err != nil {
+		return "", err
+	}
+
+	return highestSemver(tags), nil
+}
+
+func (r *Resolver) getCreds(ctx context.Context) (*dockerCreds, error) {
+	r.mu.Lock()
+	if r.creds != nil {
+		c := r.creds
+		r.mu.Unlock()
+		return c, nil
+	}
+	r.mu.Unlock()
+
+	if r.secretArn == "" {
+		return nil, fmt.Errorf("docker hub credentials secret arn not configured")
+	}
+
+	out, err := r.sm.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
+		SecretId: aws.String(r.secretArn),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get docker hub credentials: %w", err)
+	}
+	if out.SecretString == nil {
+		return nil, fmt.Errorf("docker hub credentials secret is empty")
+	}
+	var creds dockerCreds
+	if err := json.Unmarshal([]byte(*out.SecretString), &creds); err != nil {
+		return nil, fmt.Errorf("unmarshal docker hub credentials: %w", err)
+	}
+	if creds.Username == "" || creds.Password == "" {
+		return nil, fmt.Errorf("docker hub credentials missing username or password")
+	}
+
+	r.mu.Lock()
+	r.creds = &creds
+	r.mu.Unlock()
+	return &creds, nil
+}
+
+func (r *Resolver) getToken(ctx context.Context, image string, creds *dockerCreds) (string, error) {
+	q := url.Values{}
+	q.Set("service", "registry.docker.io")
+	q.Set("scope", fmt.Sprintf("repository:%s:pull", image))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, authURL+"?"+q.Encode(), nil)
+	if err != nil {
+		return "", err
+	}
+	basic := base64.StdEncoding.EncodeToString([]byte(creds.Username + ":" + creds.Password))
+	req.Header.Set("Authorization", "Basic "+basic)
+
+	resp, err := r.http.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("request docker hub token: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("docker hub token request returned %d", resp.StatusCode)
+	}
+
+	var body struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", fmt.Errorf("decode docker hub token: %w", err)
+	}
+	if body.Token == "" {
+		return "", fmt.Errorf("docker hub token response empty")
+	}
+	return body.Token, nil
+}
+
+func (r *Resolver) listTags(ctx context.Context, image, token string) ([]string, error) {
+	reqURL := fmt.Sprintf("%s/v2/%s/tags/list?n=1000", registryURL, image)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := r.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list docker hub tags: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		return nil, fmt.Errorf("docker hub tags/list returned %d: %s", resp.StatusCode, strings.TrimSpace(string(b)))
+	}
+
+	var body struct {
+		Tags []string `json:"tags"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("decode docker hub tags: %w", err)
+	}
+	return body.Tags, nil
+}
+
+// highestSemver returns the highest vX.Y.Z tag (preserving its original "v"
+// prefix form), or "" if none of the tags are real release versions.
+func highestSemver(tags []string) string {
+	type parsed struct {
+		raw     string
+		a, b, c int
+	}
+	var versions []parsed
+	for _, t := range tags {
+		m := semverTag.FindStringSubmatch(t)
+		if m == nil {
+			continue
+		}
+		a, _ := strconv.Atoi(m[1])
+		b, _ := strconv.Atoi(m[2])
+		c, _ := strconv.Atoi(m[3])
+		versions = append(versions, parsed{raw: t, a: a, b: b, c: c})
+	}
+	if len(versions) == 0 {
+		return ""
+	}
+	sort.Slice(versions, func(i, j int) bool {
+		if versions[i].a != versions[j].a {
+			return versions[i].a > versions[j].a
+		}
+		if versions[i].b != versions[j].b {
+			return versions[i].b > versions[j].b
+		}
+		return versions[i].c > versions[j].c
+	})
+	return versions[0].raw
+}
+
+// IsOutdated reports whether a node running currentTag should be nudged to
+// update to latest. latest == "" means "unknown" → never flag. When the node's
+// tag is an older semver it is outdated; per product decision, any non-semver
+// tag (e.g. the floating "latest") is also flagged so nodes get pinned to a real
+// release.
+func IsOutdated(currentTag, latest string) bool {
+	if latest == "" {
+		return false
+	}
+	cur := semverTag.FindStringSubmatch(currentTag)
+	if cur == nil {
+		return true // floating / non-release tag — nudge to pin
+	}
+	lat := semverTag.FindStringSubmatch(latest)
+	if lat == nil {
+		return false
+	}
+	ca, _ := strconv.Atoi(cur[1])
+	cb, _ := strconv.Atoi(cur[2])
+	cc, _ := strconv.Atoi(cur[3])
+	la, _ := strconv.Atoi(lat[1])
+	lb, _ := strconv.Atoi(lat[2])
+	lc, _ := strconv.Atoi(lat[3])
+	if ca != la {
+		return ca < la
+	}
+	if cb != lb {
+		return cb < lb
+	}
+	return cc < lc
+}

--- a/internal/dockerhub/dockerhub_test.go
+++ b/internal/dockerhub/dockerhub_test.go
@@ -1,0 +1,224 @@
+package dockerhub
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+)
+
+func TestHighestSemver(t *testing.T) {
+	cases := []struct {
+		name string
+		tags []string
+		want string
+	}{
+		{"empty", nil, ""},
+		{"only floating", []string{"latest", "main", "dev"}, ""},
+		{"picks highest", []string{"v1.2.0", "v1.10.1", "v1.9.9", "latest"}, "v1.10.1"},
+		{"major beats minor", []string{"v1.99.0", "v2.0.0"}, "v2.0.0"},
+		{"no v prefix", []string{"1.0.0", "2.3.4"}, "2.3.4"},
+		{"ignores partial semver", []string{"v1.2", "v1.2.3", "v1.2.3.4"}, "v1.2.3"},
+		{"preserves raw form", []string{"v3.1.0"}, "v3.1.0"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := highestSemver(c.tags); got != c.want {
+				t.Errorf("highestSemver(%v) = %q, want %q", c.tags, got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsOutdated(t *testing.T) {
+	cases := []struct {
+		name    string
+		current string
+		latest  string
+		want    bool
+	}{
+		{"unknown latest never flags", "v1.0.0", "", false},
+		{"older is outdated", "v1.0.0", "v1.2.0", true},
+		{"equal not outdated", "v1.2.0", "v1.2.0", false},
+		{"newer not outdated", "v2.0.0", "v1.2.0", false},
+		{"floating latest flagged", "latest", "v1.2.0", true},
+		{"empty tag flagged", "", "v1.2.0", true},
+		{"v-prefix mismatch tolerated", "1.0.0", "v2.0.0", true},
+		{"patch comparison", "v1.2.3", "v1.2.4", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := IsOutdated(c.current, c.latest); got != c.want {
+				t.Errorf("IsOutdated(%q, %q) = %v, want %v", c.current, c.latest, got, c.want)
+			}
+		})
+	}
+}
+
+type fakeSecrets struct {
+	value string
+	calls int
+}
+
+func (f *fakeSecrets) GetSecretValue(ctx context.Context, in *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+	f.calls++
+	return &secretsmanager.GetSecretValueOutput{SecretString: aws.String(f.value)}, nil
+}
+
+type fakeHTTP struct {
+	tokenCalls int
+	tagCalls   int
+	tags       []string
+	failTags   bool
+}
+
+func (f *fakeHTTP) Do(req *http.Request) (*http.Response, error) {
+	if strings.Contains(req.URL.Host, "auth.docker.io") {
+		f.tokenCalls++
+		return jsonResp(`{"token":"abc"}`), nil
+	}
+	f.tagCalls++
+	if f.failTags {
+		return &http.Response{StatusCode: 500, Body: io.NopCloser(strings.NewReader("boom")), Header: make(http.Header)}, nil
+	}
+	quoted := make([]string, len(f.tags))
+	for i, t := range f.tags {
+		quoted[i] = fmt.Sprintf("%q", t)
+	}
+	return jsonResp(fmt.Sprintf(`{"tags":[%s]}`, strings.Join(quoted, ","))), nil
+}
+
+func jsonResp(body string) *http.Response {
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
+}
+
+// fakeSSM holds parameters in a map. A missing key returns ParameterNotFound so
+// the read path falls through to Docker Hub.
+type fakeSSM struct {
+	params   map[string]string
+	getCalls int
+	putCalls int
+}
+
+func newFakeSSM() *fakeSSM { return &fakeSSM{params: map[string]string{}} }
+
+func (f *fakeSSM) GetParameter(ctx context.Context, in *ssm.GetParameterInput, optFns ...func(*ssm.Options)) (*ssm.GetParameterOutput, error) {
+	f.getCalls++
+	v, ok := f.params[aws.ToString(in.Name)]
+	if !ok {
+		return nil, &ssmtypes.ParameterNotFound{}
+	}
+	return &ssm.GetParameterOutput{Parameter: &ssmtypes.Parameter{Value: aws.String(v)}}, nil
+}
+
+func (f *fakeSSM) PutParameter(ctx context.Context, in *ssm.PutParameterInput, optFns ...func(*ssm.Options)) (*ssm.PutParameterOutput, error) {
+	f.putCalls++
+	f.params[aws.ToString(in.Name)] = aws.ToString(in.Value)
+	return &ssm.PutParameterOutput{}, nil
+}
+
+func newTestResolver(sm SecretsAPI, s SSMAPI, h HTTPClient) *Resolver {
+	r := NewResolver(sm, s, "arn:secret", "test")
+	r.http = h
+	return r
+}
+
+func TestLatestVersion_FallbackCachesAndSeedsSSM(t *testing.T) {
+	sm := &fakeSecrets{value: `{"username":"u","password":"p"}`}
+	s := newFakeSSM() // empty → read path falls through to Docker Hub
+	h := &fakeHTTP{tags: []string{"v1.0.0", "v1.5.0", "latest"}}
+	r := newTestResolver(sm, s, h)
+
+	if got := r.LatestVersion(context.Background(), "pennsieve/img"); got != "v1.5.0" {
+		t.Fatalf("first lookup = %q, want v1.5.0", got)
+	}
+	// Fallback should have seeded the shared SSM cache.
+	if s.putCalls != 1 {
+		t.Errorf("expected SSM seeded once, got %d puts", s.putCalls)
+	}
+	// Second call within TTL must hit L1 (no new HTTP tag calls).
+	if got := r.LatestVersion(context.Background(), "pennsieve/img"); got != "v1.5.0" {
+		t.Fatalf("cached lookup = %q, want v1.5.0", got)
+	}
+	if h.tagCalls != 1 {
+		t.Errorf("expected 1 tag call (L1 cached), got %d", h.tagCalls)
+	}
+
+	// Expire L1 and make the Docker Hub refresh fail → serve stale value.
+	r.mu.Lock()
+	r.cache["pennsieve/img"] = cacheEntry{latest: "v1.5.0", fetchedAt: time.Time{}}
+	r.mu.Unlock()
+	h.failTags = true
+	if got := r.LatestVersion(context.Background(), "pennsieve/img"); got != "v1.5.0" {
+		t.Errorf("stale-on-error = %q, want v1.5.0", got)
+	}
+}
+
+func TestLatestVersion_ReadsSharedSSMCache(t *testing.T) {
+	sm := &fakeSecrets{value: `{"username":"u","password":"p"}`}
+	s := newFakeSSM()
+	s.params["/test/account-service/provisioner-latest-tag/pennsieve/img"] = "v2.3.4"
+	h := &fakeHTTP{tags: []string{"v9.9.9"}} // must NOT be consulted
+
+	r := newTestResolver(sm, s, h)
+	if got := r.LatestVersion(context.Background(), "pennsieve/img"); got != "v2.3.4" {
+		t.Fatalf("got %q, want v2.3.4 (from SSM)", got)
+	}
+	if h.tagCalls != 0 {
+		t.Errorf("Docker Hub should not be hit when SSM has the value, got %d tag calls", h.tagCalls)
+	}
+}
+
+func TestLatestVersion_IgnoresDummyPlaceholder(t *testing.T) {
+	sm := &fakeSecrets{value: `{"username":"u","password":"p"}`}
+	s := newFakeSSM()
+	// Terraform seeds the param with "dummy" before the first refresh.
+	s.params["/test/account-service/provisioner-latest-tag/pennsieve/img"] = "dummy"
+	h := &fakeHTTP{tags: []string{"v1.4.0", "latest"}}
+
+	r := newTestResolver(sm, s, h)
+	if got := r.LatestVersion(context.Background(), "pennsieve/img"); got != "v1.4.0" {
+		t.Fatalf("got %q, want v1.4.0 (dummy ignored, fell through to Docker Hub)", got)
+	}
+	if h.tagCalls != 1 {
+		t.Errorf("expected Docker Hub fallback (1 tag call), got %d", h.tagCalls)
+	}
+}
+
+func TestRefreshAll_WritesWhitelistedImages(t *testing.T) {
+	sm := &fakeSecrets{value: `{"username":"u","password":"p"}`}
+	s := newFakeSSM()
+	s.params["/test/account-service/provisioner-images-whitelist"] = "pennsieve/a, pennsieve/b"
+	h := &fakeHTTP{tags: []string{"v1.2.3", "latest"}}
+
+	r := newTestResolver(sm, s, h)
+	if err := r.RefreshAll(context.Background()); err != nil {
+		t.Fatalf("RefreshAll: %v", err)
+	}
+	if got := s.params["/test/account-service/provisioner-latest-tag/pennsieve/a"]; got != "v1.2.3" {
+		t.Errorf("image a cached = %q, want v1.2.3", got)
+	}
+	if got := s.params["/test/account-service/provisioner-latest-tag/pennsieve/b"]; got != "v1.2.3" {
+		t.Errorf("image b cached = %q, want v1.2.3", got)
+	}
+}
+
+func TestLatestVersion_NoCredsConfigured(t *testing.T) {
+	r := NewResolver(&fakeSecrets{}, newFakeSSM(), "", "test")
+	r.http = &fakeHTTP{tags: []string{"v1.0.0"}}
+	if got := r.LatestVersion(context.Background(), "pennsieve/img"); got != "" {
+		t.Errorf("expected empty (no creds), got %q", got)
+	}
+}

--- a/internal/handler/compute/get_compute_nodes_handler.go
+++ b/internal/handler/compute/get_compute_nodes_handler.go
@@ -224,6 +224,10 @@ func GetComputesNodesHandler(ctx context.Context, request events.APIGatewayV2HTT
 	// Apply account status override and owner info to nodes
 	jsonNodes := mappers.DynamoDBNodeToJsonNodeWithAccountInfo(dynamoNodes, accountStatusMap, accountOwnerMap, nil)
 
+	// Annotate each node with the latest available provisioner version (from
+	// Docker Hub) so the frontend can hint when a node is outdated.
+	annotateLatestVersions(ctx, cfg, jsonNodes)
+
 	m, err := json.Marshal(jsonNodes)
 	if err != nil {
 		log.Println(err.Error())

--- a/internal/handler/compute/node_versions.go
+++ b/internal/handler/compute/node_versions.go
@@ -1,0 +1,59 @@
+package compute
+
+import (
+	"context"
+	"os"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/pennsieve/account-service/internal/dockerhub"
+	"github.com/pennsieve/account-service/internal/models"
+)
+
+// defaultProvisionerImage mirrors the default in post_compute_nodes_handler.go;
+// legacy nodes stored before ProvisionerImage was persisted have an empty value.
+const defaultProvisionerImage = "pennsieve/compute-node-aws-provisioner-v2"
+
+// resolver is a process-wide singleton so its tag cache survives across warm
+// Lambda invocations (built once on first use).
+var (
+	resolverOnce sync.Once
+	resolver     *dockerhub.Resolver
+)
+
+func getResolver(cfg aws.Config) *dockerhub.Resolver {
+	resolverOnce.Do(func() {
+		sm := secretsmanager.NewFromConfig(cfg)
+		ssmClient := ssm.NewFromConfig(cfg)
+		resolver = dockerhub.NewResolver(sm, ssmClient, os.Getenv("DOCKER_HUB_CREDENTIALS_SECRET_ARN"), os.Getenv("ENV"))
+	})
+	return resolver
+}
+
+// annotateLatestVersions fills LatestVersion/UpdateAvailable on each node by
+// looking up the newest released provisioner tag on Docker Hub (cached per
+// image). It degrades gracefully: if a lookup fails, LatestVersion stays empty
+// and UpdateAvailable stays false — the list call never fails over this.
+func annotateLatestVersions(ctx context.Context, cfg aws.Config, nodes []models.Node) {
+	if len(nodes) == 0 {
+		return
+	}
+	r := getResolver(cfg)
+
+	latestByImage := make(map[string]string)
+	for i := range nodes {
+		image := nodes[i].ProvisionerImage
+		if image == "" {
+			image = defaultProvisionerImage
+		}
+		latest, ok := latestByImage[image]
+		if !ok {
+			latest = r.LatestVersion(ctx, image)
+			latestByImage[image] = latest
+		}
+		nodes[i].LatestVersion = latest
+		nodes[i].UpdateAvailable = dockerhub.IsOutdated(nodes[i].ProvisionerImageTag, latest)
+	}
+}

--- a/internal/handler/healthchecker/handler.go
+++ b/internal/handler/healthchecker/handler.go
@@ -29,11 +29,18 @@ type Config struct {
 	AWSCfg aws.Config
 }
 
+// TagRefresher refreshes the shared cache of latest provisioner image tags
+// (implemented by *dockerhub.Resolver). Optional — nil disables the refresh.
+type TagRefresher interface {
+	RefreshAll(ctx context.Context) error
+}
+
 type Handler struct {
 	NodeStore      store_dynamodb.NodeStore
 	HealthLogStore store_dynamodb.HealthCheckLogStore
 	DDBClient      *dynamodb.Client
 	LayersTable    string
+	TagRefresher   TagRefresher
 	Config         Config
 }
 
@@ -45,6 +52,17 @@ type result struct {
 }
 
 func (h *Handler) Handle(ctx context.Context) error {
+	// Refresh the shared latest-provisioner-tag cache so GET /compute-nodes can
+	// flag outdated nodes without hitting Docker Hub on the request path.
+	// Best-effort: a failure here must not fail the health check.
+	if h.TagRefresher != nil {
+		if err := h.TagRefresher.RefreshAll(ctx); err != nil {
+			log.Printf("Provisioner tag refresh failed (continuing): %v", err)
+		} else {
+			log.Println("Provisioner tag cache refreshed")
+		}
+	}
+
 	nodes, err := h.NodeStore.GetAllEnabled(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get enabled nodes: %w", err)

--- a/internal/models/node.go
+++ b/internal/models/node.go
@@ -47,6 +47,14 @@ type Node struct {
 	Status                 string          `json:"status"`
 	HealthStatus           string          `json:"healthStatus,omitempty"`
 	LastHealthCheck        string          `json:"lastHealthCheck,omitempty"`
+	// LatestVersion is the newest real vX.Y.Z provisioner image tag available on
+	// Docker Hub for this node's ProvisionerImage. Empty when it can't be
+	// determined (Docker Hub unreachable, no released versions, etc.).
+	LatestVersion string `json:"latestVersion,omitempty"`
+	// UpdateAvailable is true when the node's provisioner tag is behind
+	// LatestVersion (or is a floating tag like "latest"). Always false when
+	// LatestVersion is unknown.
+	UpdateAvailable bool `json:"updateAvailable"`
 }
 
 type NodeAccount struct {

--- a/terraform/accounts-service.yml
+++ b/terraform/accounts-service.yml
@@ -302,6 +302,12 @@ components:
           type: string
           enum: ["Enabled", "Paused", "Pending", "Destroying"]
           description: Current status of the compute node
+        latestVersion:
+          type: string
+          description: Newest released provisioner image tag (vX.Y.Z) available on Docker Hub for this node's provisioner image. Omitted when it cannot be determined.
+        updateAvailable:
+          type: boolean
+          description: True when the node's provisioner tag is behind latestVersion (or is a floating tag such as 'latest'). Always false when latestVersion is unknown.
     computeNodeUpdateRequest:
       type: object
       properties:

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -85,6 +85,20 @@ data "aws_iam_policy_document" "service_iam_policy_document" {
     ]
   }
 
+  // Docker Hub credentials (shared with the ECS provisioner): the service Lambda
+  // reads these to query the private provisioner repo for the latest released
+  // image tag, used to flag outdated compute nodes on GET /compute-nodes.
+  statement {
+    sid    = "AccountServiceDockerHubCredentials"
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+    resources = [
+      data.terraform_remote_state.platform_infrastructure.outputs.docker_hub_credentials_arn,
+    ]
+  }
+
   statement {
     sid    = "LambdaAccessToDynamoDB"
     effect = "Allow"
@@ -317,6 +331,31 @@ data "aws_iam_policy_document" "health_checker_iam_policy_document" {
     resources = [
       data.terraform_remote_state.workflow_service.outputs.compute_node_layers_table_arn,
       "${data.terraform_remote_state.workflow_service.outputs.compute_node_layers_table_arn}/*"
+    ]
+  }
+
+  // Reads the provisioner whitelist and writes the shared latest-tag cache that
+  // GET /compute-nodes reads to flag outdated nodes.
+  statement {
+    sid    = "HealthCheckerProvisionerTagCache"
+    effect = "Allow"
+    actions = [
+      "ssm:GetParameter",
+      "ssm:PutParameter"
+    ]
+    resources = ["arn:aws:ssm:${data.aws_region.current_region.name}:${data.aws_caller_identity.current.account_id}:parameter/${var.environment_name}/${var.service_name}/*"]
+  }
+
+  // Docker Hub credentials (shared with the ECS provisioner) for querying the
+  // private provisioner repo's tags.
+  statement {
+    sid    = "HealthCheckerDockerHubCredentials"
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue"
+    ]
+    resources = [
+      data.terraform_remote_state.platform_infrastructure.outputs.docker_hub_credentials_arn
     ]
   }
 

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -59,6 +59,9 @@ resource "aws_lambda_function" "service_lambda" {
       STORAGE_WRITE_POLICY_ARN        = aws_iam_policy.storage_write.arn
       STORAGE_TASK_DEF_ARN            = aws_ecs_task_definition.storage_provisioner_task.arn
       STORAGE_TASK_DEF_CONTAINER_NAME = "storage-provisioner"
+      # Docker Hub credentials (shared with the ECS provisioner) used to look up
+      # the latest released provisioner image tag for the outdated-node hint.
+      DOCKER_HUB_CREDENTIALS_SECRET_ARN = data.terraform_remote_state.platform_infrastructure.outputs.docker_hub_credentials_arn
     }
   }
 }
@@ -293,6 +296,9 @@ resource "aws_lambda_function" "health_checker_lambda" {
       COMPUTE_NODES_TABLE       = aws_dynamodb_table.compute_resource_nodes_table.name
       HEALTH_CHECK_LOG_TABLE    = aws_dynamodb_table.health_check_log_table.name
       COMPUTE_NODE_LAYERS_TABLE = data.terraform_remote_state.workflow_service.outputs.compute_node_layers_table_name
+      # Docker Hub credentials (shared with the ECS provisioner): the health
+      # checker refreshes the shared latest-provisioner-tag SSM cache each run.
+      DOCKER_HUB_CREDENTIALS_SECRET_ARN = data.terraform_remote_state.platform_infrastructure.outputs.docker_hub_credentials_arn
     }
   }
 }

--- a/terraform/ssm.tf
+++ b/terraform/ssm.tf
@@ -1,10 +1,43 @@
+locals {
+  # Source of truth for the allowed provisioner images. Drives both the
+  # whitelist parameter and the per-image latest-tag cache parameters.
+  provisioner_images = [
+    "pennsieve/compute-node-aws-provisioner",
+    "pennsieve/compute-node-aws-provisioner-v2",
+  ]
+}
+
 # PROVISIONER IMAGES WHITELIST
 resource "aws_ssm_parameter" "provisioner_images_whitelist" {
   name  = "/${var.environment_name}/${var.service_name}/provisioner-images-whitelist"
   type  = "String"
-  value = "pennsieve/compute-node-aws-provisioner,pennsieve/compute-node-aws-provisioner-v2"
+  value = join(",", local.provisioner_images)
 
   description = "Comma-separated list of allowed provisioner Docker images"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+
+  tags = {
+    Environment = var.environment_name
+    Service     = var.service_name
+  }
+}
+
+# PROVISIONER LATEST-TAG CACHE
+# One parameter per provisioner image, seeded with a placeholder. The
+# health-checker Lambda overwrites the value each run with the newest released
+# vX.Y.Z tag from Docker Hub; GET /compute-nodes reads it to flag outdated nodes.
+# ignore_changes keeps Terraform from reverting the runtime-managed value.
+resource "aws_ssm_parameter" "provisioner_latest_tag" {
+  for_each = toset(local.provisioner_images)
+
+  name  = "/${var.environment_name}/${var.service_name}/provisioner-latest-tag/${each.value}"
+  type  = "String"
+  value = "dummy"
+
+  description = "Latest released ${each.value} image tag (managed at runtime by the health-checker)"
 
   lifecycle {
     ignore_changes = [value]


### PR DESCRIPTION
## What

`GET /compute-nodes` now returns two new fields per node:

- **`latestVersion`** — the newest released `vX.Y.Z` provisioner image tag on Docker Hub for the node's provisioner image (never `latest`)
- **`updateAvailable`** — `true` when the node's pinned tag is behind `latestVersion`, or when it's a floating tag like `latest` (per product decision: nudge nodes onto pinned releases). Always `false` when the latest version can't be determined.

The frontend renders the "update available" hint off these fields.

## How — Docker Hub is off the request path

The provisioner repo is **private** on Docker Hub, so we authenticate with the same credentials the ECS provisioner uses (`docker_hub_credentials_arn`). Latest tag is resolved via a 3-tier cache so a busy, cold-start-heavy list endpoint never blocks on Docker Hub:

1. **L1** — in-process map (warm container, 5-min TTL)
2. **L2** — shared SSM param `/{env}/account-service/provisioner-latest-tag/{image}` (~10–30 ms; this is what cold starts pay instead of a ~400 ms Docker Hub round-trip)
3. **Fallback** — direct Docker Hub lookup only if SSM is unpopulated or the scheduler failed; self-healing, and it seeds SSM for the next cold start

**Refresh:** the existing **health-checker Lambda (every 30 min)** now refreshes the shared SSM cache each run (best-effort — never fails the health run). Net: Docker Hub is hit ~2×/hour regardless of traffic; staleness ≤30 min.

## Terraform

- `ssm.tf` declares the cache params via `for_each` over a shared `local.provisioner_images` list, seeded `value = "dummy"` with `ignore_changes = [value]` — matching the existing whitelist pattern. The whitelist now derives from the same list (no value change). Non-semver values (the `dummy` placeholder) are treated as a cache miss, so the API never surfaces junk before the first refresh.
- Health-checker role gains `ssm:GetParameter`/`ssm:PutParameter` on the service path + `secretsmanager:GetSecretValue` on the Docker creds + the `DOCKER_HUB_CREDENTIALS_SECRET_ARN` env var. The service Lambda's existing `ssm:GetParameter` on `/{env}/account-service/*` already covers the read path.

## Tests

New `internal/dockerhub` unit tests cover semver selection, `IsOutdated` semantics, the SSM-hit / Docker-Hub-fallback / dummy-placeholder / stale-on-error paths, and `RefreshAll`. Build + vet + `terraform fmt` clean.

## Notes

- VPC/NAT: only the health-checker (and the rare inline fallback) reach Docker Hub now — not every list call.
- Scoped to the **list** endpoint; the single-node `GET /compute-nodes/{id}` doesn't get the fields yet (the resolver is reusable if we want it there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)