### PR TITLE
assume in-account role for secrets & allowed-processors gateway calls

### DIFF
--- a/internal/clients/crossaccount.go
+++ b/internal/clients/crossaccount.go
@@ -1,0 +1,38 @@
+package clients
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+// AssumeComputeRoleConfig returns an aws.Config whose credentials come from assuming
+// the compute node's cross-account role (account.RoleName) in the customer's AWS
+// account. Requests signed with this config present an *in-account* principal.
+//
+// This matters for calls to the compute gateway: signing with account-service's own
+// (Pennsieve) identity makes the request an external, cross-org principal, which is
+// denied by customer AWS Organizations guardrails (RCPs) that block access from
+// accounts outside their org — even when IAM and the gateway's resource policy allow
+// it. Assuming the in-account role sidesteps that guardrail entirely.
+//
+// The SDK wraps the assume-role provider in a credentials cache, so the STS call
+// happens once per config and credentials refresh automatically as needed.
+func AssumeComputeRoleConfig(ctx context.Context, cfg aws.Config, accountId, roleName, region string) (aws.Config, error) {
+	stsClient := sts.NewFromConfig(cfg)
+	roleArn := fmt.Sprintf("arn:aws:iam::%s:role/%s", accountId, roleName)
+	crossAccountCfg, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion(region),
+		config.WithCredentialsProvider(
+			stscreds.NewAssumeRoleProvider(stsClient, roleArn),
+		),
+	)
+	if err != nil {
+		return aws.Config{}, fmt.Errorf("assuming compute role %s: %w", roleArn, err)
+	}
+	return crossAccountCfg, nil
+}

--- a/internal/clients/crossaccount.go
+++ b/internal/clients/crossaccount.go
@@ -13,15 +13,6 @@ import (
 // AssumeComputeRoleConfig returns an aws.Config whose credentials come from assuming
 // the compute node's cross-account role (account.RoleName) in the customer's AWS
 // account. Requests signed with this config present an *in-account* principal.
-//
-// This matters for calls to the compute gateway: signing with account-service's own
-// (Pennsieve) identity makes the request an external, cross-org principal, which is
-// denied by customer AWS Organizations guardrails (RCPs) that block access from
-// accounts outside their org — even when IAM and the gateway's resource policy allow
-// it. Assuming the in-account role sidesteps that guardrail entirely.
-//
-// The SDK wraps the assume-role provider in a credentials cache, so the STS call
-// happens once per config and credentials refresh automatically as needed.
 func AssumeComputeRoleConfig(ctx context.Context, cfg aws.Config, accountId, roleName, region string) (aws.Config, error) {
 	stsClient := sts.NewFromConfig(cfg)
 	roleArn := fmt.Sprintf("arn:aws:iam::%s:role/%s", accountId, roleName)

--- a/internal/handler/compute/secrets_helpers.go
+++ b/internal/handler/compute/secrets_helpers.go
@@ -140,7 +140,33 @@ func initSecretsContext(ctx context.Context, request events.APIGatewayV2HTTPRequ
 		region = "us-east-1"
 	}
 
-	pc := clients.NewProvisionerClient(node.ComputeNodeGatewayUrl, region, cfg)
+	// Look up the compute account so we can assume its cross-account role. Signing the
+	// gateway call as an in-account principal (rather than account-service's own
+	// Pennsieve identity) keeps the request from being denied by customer AWS
+	// Organizations guardrails (RCPs) that block callers from outside their org.
+	accountsTable := os.Getenv("ACCOUNTS_TABLE")
+	accountStore := store_dynamodb.NewAccountDatabaseStore(dynamoDBClient, accountsTable)
+	account, err := accountStore.GetById(ctx, node.AccountUuid)
+	if err != nil {
+		log.Printf("Error getting account %s for node %s: %v", node.AccountUuid, nodeUuid, err)
+		resp := events.APIGatewayV2HTTPResponse{
+			StatusCode: http.StatusInternalServerError,
+			Body:       errors.ComputeHandlerError(handlerName, errors.ErrDynamoDB),
+		}
+		return nil, &resp
+	}
+
+	crossAccountCfg, err := clients.AssumeComputeRoleConfig(ctx, cfg, account.AccountId, account.RoleName, region)
+	if err != nil {
+		log.Printf("Error assuming cross-account role for account %s (node %s): %v", account.AccountId, nodeUuid, err)
+		resp := events.APIGatewayV2HTTPResponse{
+			StatusCode: http.StatusInternalServerError,
+			Body:       errors.ComputeHandlerError(handlerName, errors.ErrConfig),
+		}
+		return nil, &resp
+	}
+
+	pc := clients.NewProvisionerClient(node.ComputeNodeGatewayUrl, region, crossAccountCfg)
 
 	return &secretsContext{
 		UserID:            userId,

--- a/internal/handler/compute/secrets_helpers.go
+++ b/internal/handler/compute/secrets_helpers.go
@@ -142,10 +142,7 @@ func initSecretsContext(ctx context.Context, request events.APIGatewayV2HTTPRequ
 		region = os.Getenv("AWS_REGION")
 	}
 
-	// Look up the compute account so we can assume its cross-account role. Signing the
-	// gateway call as an in-account principal (rather than account-service's own
-	// Pennsieve identity) keeps the request from being denied by customer AWS
-	// Organizations guardrails (RCPs) that block callers from outside their org.
+	// Look up the compute account so we can assume its cross-account role. 
 	accountsTable := os.Getenv("ACCOUNTS_TABLE")
 	accountStore := store_dynamodb.NewAccountDatabaseStore(dynamoDBClient, accountsTable)
 	account, err := accountStore.GetById(ctx, node.AccountUuid)

--- a/internal/handler/compute/secrets_helpers.go
+++ b/internal/handler/compute/secrets_helpers.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -135,9 +136,10 @@ func initSecretsContext(ctx context.Context, request events.APIGatewayV2HTTPRequ
 		return nil, &resp
 	}
 
-	region := os.Getenv("AWS_REGION")
+	// Get the region from the compute node's gateway URL
+	region := regionFromGatewayURL(node.ComputeNodeGatewayUrl)
 	if region == "" {
-		region = "us-east-1"
+		region = os.Getenv("AWS_REGION")
 	}
 
 	// Look up the compute account so we can assume its cross-account role. Signing the
@@ -174,6 +176,17 @@ func initSecretsContext(ctx context.Context, request events.APIGatewayV2HTTPRequ
 		Node:              node,
 		ProvisionerClient: pc,
 	}, nil
+}
+
+func regionFromGatewayURL(gatewayURL string) string {
+	// URL form: https://{url-id}.lambda-url.{region}.on.aws/
+	parts := strings.Split(gatewayURL, ".")
+	if len(parts) < 3 || parts[1] != "lambda-url" {
+		return ""
+	}
+	region := parts[2]
+
+	return region
 }
 
 func checkNodeAccess(ctx context.Context, lambdaClient *lambda.Client, dynamoDBClient *dynamodb.Client, handlerName, userId, nodeUuid, organizationId string) *events.APIGatewayV2HTTPResponse {

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -221,9 +221,7 @@ data "aws_iam_policy_document" "service_iam_policy_document" {
   }
 
   # Assume the compute node's in-account role so gateway calls (secrets,
-  # allowed-processors) are signed as an in-account principal. Without this,
-  # customer Organizations guardrails (RCPs) reject account-service's own
-  # (external) identity even though InvokeComputeGatewayUrl above allows it.
+  # allowed-processors) are signed as an in-account principal.
   statement {
     sid    = "AllowAssumeComputeRole"
     effect = "Allow"

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -220,6 +220,21 @@ data "aws_iam_policy_document" "service_iam_policy_document" {
     resources = ["arn:aws:lambda:*:*:function:compute-gateway-*"]
   }
 
+  # Assume the compute node's in-account role so gateway calls (secrets,
+  # allowed-processors) are signed as an in-account principal. Without this,
+  # customer Organizations guardrails (RCPs) reject account-service's own
+  # (external) identity even though InvokeComputeGatewayUrl above allows it.
+  statement {
+    sid    = "AllowAssumeComputeRole"
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole",
+    ]
+    resources = [
+      "arn:aws:iam::*:role/Pennsieve-Compute-*",
+    ]
+  }
+
 }
 
 


### PR DESCRIPTION
Ember team was having issues with updating their secrets.

Previously we were calling the lambda function gateway via resource based policy which we suspect their IT was blocking at a higher level.

Now we do it via cross-account role assumption which seems to be the default method to make the call across all of our cross account services, as well as other places in this repo
